### PR TITLE
test(vscode): add regression coverage for issue #24

### DIFF
--- a/editors/vscode/src/test/suite/index.ts
+++ b/editors/vscode/src/test/suite/index.ts
@@ -11,6 +11,7 @@ export function run(): Promise<void> {
   require("./debug-io.integration.test");
   require("./hmi.integration.test");
   require("./lsp.integration.test");
+  require("./runtime-default-settings.integration.test");
   require("./new-project.test");
   require("./plcopen-export.test");
   require("./plcopen-import.test");

--- a/editors/vscode/src/test/suite/runtime-default-settings.integration.test.ts
+++ b/editors/vscode/src/test/suite/runtime-default-settings.integration.test.ts
@@ -1,0 +1,19 @@
+import * as assert from "assert";
+import * as vscode from "vscode";
+
+suite("Runtime default settings integration (VS Code)", function () {
+  test("activation does not seed runtime control endpoint into workspace folder settings", async () => {
+    const workspaceFolder = vscode.workspace.workspaceFolders?.[0];
+    assert.ok(workspaceFolder, "Expected a workspace folder for tests.");
+
+    const config = vscode.workspace.getConfiguration("trust-lsp", workspaceFolder.uri);
+    const inspected = config.inspect<string>("runtime.controlEndpoint");
+
+    assert.ok(inspected, "Expected runtime.controlEndpoint inspection metadata.");
+    assert.strictEqual(
+      inspected?.workspaceFolderValue,
+      undefined,
+      "runtime.controlEndpoint should not be written into workspace folder settings during activation."
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add a VS Code integration regression for the runtime default settings behavior
- verify activation does not write `trust-lsp.runtime.controlEndpoint` into workspace-folder settings
- keep production code unchanged because current `main` already behaves correctly

## Validation
- `cd editors/vscode && npm run lint`
- `cd editors/vscode && npm run compile`
- `cd editors/vscode && npm test` passed on the identical diff before the split; the fresh split worktree was rebuilding the local Rust test server/toolchain cache from scratch, so I did not wait for a redundant second pass there

Refs #24