### PR TITLE
ci(msrv): resolve Rust 1.85 dependency drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,6 +265,8 @@ jobs:
       - uses: dtolnay/rust-toolchain@1.85
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --all-targets
+        env:
+          CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS: fallback
       - name: Mark gate success
         if: ${{ success() }}
         run: |


### PR DESCRIPTION
## Summary
- make the MSRV job use Cargo's rust-version-aware fallback resolver
- keep the job working on checkouts without a tracked `Cargo.lock`
- restore Rust 1.85-compatible resolution for transitive crates such as `icu_*` and `image`

## Validation
- `CARGO_RESOLVER_INCOMPATIBLE_RUST_VERSIONS=fallback cargo +1.85-aarch64-unknown-linux-gnu check --all-targets`
- repo pre-commit checks passed during commit