### PR TITLE
fix(hir): support infix bitwise any-bit typing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Target release: `v0.9.29`
 ### Fixed
 
 - Runtime assignment writes now preserve declared scalar storage types in both interpreter and VM paths, so loop counters keep their declared `INT`/`UINT`/etc. representation and exact-source conversion calls such as `INT_TO_DINT(...)` no longer fail inside `FOR` and `WHILE` loops.
+- Structured Text infix bitwise operators now accept `BOOL`/`ANY_BIT` operands with the same widening behavior as the standard `AND`/`OR`/`XOR`/`NOT` functions, and `&` now type-checks as the `AND` synonym instead of falling through as `UNKNOWN`.
 
 ### Added
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,10 @@ Thanks for taking the time to contribute. This project is early-stage and still 
 Prerequisites:
 - Rust 1.85+
 - Node.js 20+ (for the VS Code extension)
+- [just](https://github.com/casey/just) (task runner used by the repo)
+
+Optional:
+- [sccache](https://github.com/mozilla/sccache) (for faster local Rust builds)
 
 Clone and build:
 

--- a/crates/trust-hir/src/type_check/expr.rs
+++ b/crates/trust-hir/src/type_check/expr.rs
@@ -204,9 +204,13 @@ impl<'a, 'b> ExprChecker<'a, 'b> {
             self.check_comparable(lhs_type, rhs_type, node.text_range());
             TypeId::BOOL
         } else if op.is_logical() {
-            self.check_boolean(lhs_type, node.text_range());
-            self.check_boolean(rhs_type, node.text_range());
-            TypeId::BOOL
+            self.common_bit_string_type(
+                lhs_type,
+                lhs_node.text_range(),
+                rhs_type,
+                rhs_node.text_range(),
+                node.text_range(),
+            )
         } else if op.is_arithmetic() {
             if let (Some(lhs_ty), Some(rhs_ty)) = (
                 self.checker
@@ -251,10 +255,7 @@ impl<'a, 'b> ExprChecker<'a, 'b> {
                 );
                 TypeId::UNKNOWN
             }
-            UnaryOp::Not => {
-                self.check_boolean(operand, node.text_range());
-                TypeId::BOOL
-            }
+            UnaryOp::Not => self.unary_bit_string_type(operand, node.text_range()),
             UnaryOp::Unknown => TypeId::UNKNOWN,
         }
     }
@@ -303,6 +304,64 @@ impl<'a, 'b> ExprChecker<'a, 'b> {
             range,
             "types are not comparable",
         );
+    }
+
+    pub(super) fn common_bit_string_type(
+        &mut self,
+        lhs: TypeId,
+        lhs_range: TextRange,
+        rhs: TypeId,
+        rhs_range: TextRange,
+        range: TextRange,
+    ) -> TypeId {
+        let lhs = self.checker.resolve_subrange_base(lhs);
+        let rhs = self.checker.resolve_subrange_base(rhs);
+        let lhs_ty = self.checker.resolved_type(lhs);
+        let rhs_ty = self.checker.resolved_type(rhs);
+
+        match (lhs_ty, rhs_ty) {
+            (Some(l), Some(r)) if l.is_bit_string() && r.is_bit_string() => {
+                let lhs_size = l.bit_size().unwrap_or(0);
+                let rhs_size = r.bit_size().unwrap_or(0);
+                let common = if lhs_size >= rhs_size { lhs } else { rhs };
+
+                if lhs != common {
+                    self.checker
+                        .warn_implicit_conversion(common, lhs, lhs_range);
+                }
+                if rhs != common {
+                    self.checker
+                        .warn_implicit_conversion(common, rhs, rhs_range);
+                }
+
+                common
+            }
+            (None, _) | (_, None) => TypeId::UNKNOWN,
+            _ => {
+                self.checker.diagnostics.error(
+                    DiagnosticCode::TypeMismatch,
+                    range,
+                    "operands must be BOOL or bit-string types",
+                );
+                TypeId::UNKNOWN
+            }
+        }
+    }
+
+    pub(super) fn unary_bit_string_type(&mut self, operand: TypeId, range: TextRange) -> TypeId {
+        let operand = self.checker.resolve_subrange_base(operand);
+        match self.checker.resolved_type(operand) {
+            Some(ty) if ty.is_bit_string() => operand,
+            None => TypeId::UNKNOWN,
+            _ => {
+                self.checker.diagnostics.error(
+                    DiagnosticCode::TypeMismatch,
+                    range,
+                    "NOT requires BOOL or bit-string type",
+                );
+                TypeId::UNKNOWN
+            }
+        }
     }
 
     pub(super) fn common_numeric_type(

--- a/crates/trust-hir/src/type_check/ops.rs
+++ b/crates/trust-hir/src/type_check/ops.rs
@@ -47,6 +47,7 @@ impl BinaryOp {
                 SyntaxKind::LtEq => return Self::LtEq,
                 SyntaxKind::Gt => return Self::Gt,
                 SyntaxKind::GtEq => return Self::GtEq,
+                SyntaxKind::Ampersand => return Self::And,
                 SyntaxKind::KwAnd => return Self::And,
                 SyntaxKind::KwOr => return Self::Or,
                 SyntaxKind::KwXor => return Self::Xor,

--- a/crates/trust-hir/tests/semantic_type_checking/control_flow_and_calls.rs
+++ b/crates/trust-hir/tests/semantic_type_checking/control_flow_and_calls.rs
@@ -627,3 +627,64 @@ END_PROGRAM
 "#,
     );
 }
+
+#[test]
+fn test_infix_bitwise_any_bit_expressions_are_allowed() {
+    check_no_errors(
+        r#"
+PROGRAM Test
+    VAR
+        a : WORD := WORD#16#FF00;
+        b : WORD := WORD#16#0F0F;
+        r : WORD;
+    END_VAR
+    r := a AND b;
+    r := a OR b;
+    r := a XOR b;
+    r := NOT a;
+END_PROGRAM
+"#,
+    );
+}
+
+#[test]
+fn test_infix_ampersand_matches_and_for_bit_strings() {
+    let errors = check_errors(
+        r#"
+PROGRAM Test
+    VAR
+        w : WORD := WORD#16#FF00;
+        dw : DWORD := DWORD#16#0000_F0F0;
+    END_VAR
+    w := w & dw;
+END_PROGRAM
+"#,
+    );
+    assert_eq!(
+        errors,
+        vec![DiagnosticCode::IncompatibleAssignment],
+        "Expected '&' to widen like AND and only fail on the narrowing assignment, got: {:?}",
+        errors
+    );
+}
+
+#[test]
+fn test_infix_bitwise_mixed_width_results_cannot_shrink_silently() {
+    let errors = check_errors(
+        r#"
+PROGRAM Test
+    VAR
+        w : WORD := WORD#16#FF00;
+        dw : DWORD := DWORD#16#0000_F0F0;
+    END_VAR
+    w := w AND dw;
+END_PROGRAM
+"#,
+    );
+    assert_eq!(
+        errors,
+        vec![DiagnosticCode::IncompatibleAssignment],
+        "Expected only the narrowing assignment error, got: {:?}",
+        errors
+    );
+}

--- a/docs/IEC_DECISIONS.md
+++ b/docs/IEC_DECISIONS.md
@@ -52,3 +52,13 @@ This file tracks implementation decisions made where IEC 61131-3 leaves room for
   - Core LD semantics are specified to remain compatible with common Edition 2 usage patterns.
 - Reason:
   - Keeps a single normative baseline while avoiding unnecessary migration breakage for existing LD logic.
+
+## 2026-04-11 - Mixed-width infix bitwise result typing
+
+- Area: ST expression typing
+- IEC context: IEC 61131-3 Ed.3 expression semantics allow `AND`/`OR`/`XOR`/`NOT` on bit strings, but mixed-width infix result typing is not stated concretely enough for interoperable implementation behavior.
+- Decision:
+  - Infix `AND`, `&`, `OR`, and `XOR` on `ANY_BIT` operands widen to the wider operand type.
+  - Infix `NOT` preserves the operand type.
+- Reason:
+  - This keeps infix operators aligned with the existing standard-function `ANY_BIT` behavior and avoids divergent typing between `a AND b` and `AND(a, b)`.

--- a/docs/specs/05-expressions.md
+++ b/docs/specs/05-expressions.md
@@ -172,6 +172,9 @@ IntVar := REAL_TO_INT(RealVar);
 
 **Bitwise Operations** (when applied to ANY_BIT types):
 
+- `AND`, `&`, `OR`, and `XOR` operate on bit strings and produce the wider operand type when widths differ.
+- `NOT` preserves the operand bit-string type.
+
 ```
 // BYTE operations
 B1 := 16#F0;
@@ -289,7 +292,7 @@ ptr^                // Dereference
 | Operation | Operand Types | Result |
 |-----------|---------------|--------|
 | AND, OR, XOR | BOOL | BOOL |
-| AND, OR, XOR | ANY_BIT | Same bit width |
+| AND, OR, XOR | ANY_BIT | Wider of operands |
 | NOT | BOOL | BOOL |
 | NOT | ANY_BIT | Same bit width |
 


### PR DESCRIPTION
## Summary
- type-check infix `AND`/`OR`/`XOR` for `BOOL`/`ANY_BIT` operands with widening
- preserve unary `NOT` operand type and treat `&` as the `AND` synonym
- carry the small `CONTRIBUTING.md` `just`/`sccache` docs cleanup so the good part of #23 is not lost

## Tests
- cargo test -p trust-hir --test semantic_type_checking
- cargo test -p trust-hir --test semantic_standard_functions

## Notes
- supersedes #25 for the IEC-aligned bitwise fix
- includes the useful docs cleanup from #23 without the bad `.gitignore` change