### PR TITLE
feat(runtime): add trust-harness cycle dt driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ Target release: `v0.9.29`
 
 ### Added
 
+- `trust-harness` now provides a lightweight JSON-line test driver for compiled ST programs, including `cycle.dt_ms` virtual-time advancement and typed `TIME`/`LTIME` watch output for timer-oriented automation.
+
 - VS Code SFC visual editor integration (IEC 61131-3 style step/transition canvas, runtime panel wiring, and bundled EtherCAT Snake SFC examples) is now included in mainline extension workflows.
 - MP-060 Phase A execution-backend controls for `trust-runtime`: new `runtime.execution_backend` config (`interpreter|vm`), new CLI override `--execution-backend=interpreter|vm` for `run`/`play`, startup backend-selection log event, backend mode/source fields in control `status`/`config.get`, and Prometheus backend info metric (`trust_runtime_execution_backend_info`). `vm` selection is intentionally fail-fast until VM execution lands in the next MP-060 phase.
 - MP-060 Phase B VM core for `trust-runtime`: `runtime.execution_backend='vm'` now runs a real bytecode executor with deterministic program-counter dispatch, operand and call/frame stacks, trap/deadline/budget enforcement, stable trap-to-`RuntimeError` mapping, and slot/index-based VM hot-path access with symbol/source mapping tables preserved for external/debug name-based surfaces. Interpreter remains the default backend.

--- a/crates/trust-runtime/src/bin/trust-harness.rs
+++ b/crates/trust-runtime/src/bin/trust-harness.rs
@@ -1,0 +1,203 @@
+//! Minimal JSON-line harness for deterministic cycle driving.
+
+use std::io::{self, BufRead, Write};
+
+use anyhow::{anyhow, Context};
+use serde::Deserialize;
+use serde_json::{json, Map, Value as JsonValue};
+use trust_runtime::harness::TestHarness;
+use trust_runtime::value::{Duration, Value};
+
+#[derive(Debug, Deserialize)]
+struct Request {
+    cmd: String,
+    source: Option<String>,
+    count: Option<u32>,
+    dt_ms: Option<i64>,
+    watch: Option<Vec<String>>,
+}
+
+fn main() -> anyhow::Result<()> {
+    let stdin = io::stdin();
+    let stdout = io::stdout();
+    let mut out = stdout.lock();
+    let mut harness: Option<TestHarness> = None;
+
+    for line in stdin.lock().lines() {
+        let line = line.context("read stdin line")?;
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        let response = match serde_json::from_str::<Request>(&line) {
+            Ok(request) => handle_request(request, &mut harness),
+            Err(err) => error_response(format!("invalid request: {err}")),
+        };
+
+        writeln!(out, "{}", serde_json::to_string(&response)?)?;
+        out.flush()?;
+    }
+
+    Ok(())
+}
+
+fn handle_request(request: Request, harness: &mut Option<TestHarness>) -> JsonValue {
+    match dispatch_request(request, harness) {
+        Ok(data) => json!({
+            "ok": true,
+            "data": data,
+        }),
+        Err(err) => error_response(err.to_string()),
+    }
+}
+
+fn dispatch_request(
+    request: Request,
+    harness: &mut Option<TestHarness>,
+) -> anyhow::Result<JsonValue> {
+    match request.cmd.as_str() {
+        "load" => handle_load(request, harness),
+        "cycle" => handle_cycle(request, harness),
+        other => Err(anyhow!("unsupported command '{other}'")),
+    }
+}
+
+fn handle_load(request: Request, harness: &mut Option<TestHarness>) -> anyhow::Result<JsonValue> {
+    let source = request
+        .source
+        .as_deref()
+        .ok_or_else(|| anyhow!("load requires 'source'"))?;
+    let mut loaded = TestHarness::from_source(source)?;
+    let cycle = loaded.cycle();
+    if !cycle.errors.is_empty() {
+        let rendered = cycle
+            .errors
+            .iter()
+            .map(std::string::ToString::to_string)
+            .collect::<Vec<_>>()
+            .join("; ");
+        return Err(anyhow!("initial cycle failed: {rendered}"));
+    }
+    *harness = Some(loaded);
+    Ok(json!({
+        "cycle_count": 1,
+        "elapsed_ms": 0,
+    }))
+}
+
+fn handle_cycle(request: Request, harness: &mut Option<TestHarness>) -> anyhow::Result<JsonValue> {
+    let harness = harness
+        .as_mut()
+        .ok_or_else(|| anyhow!("cycle requires a loaded program"))?;
+    let count = request.count.unwrap_or(1);
+
+    if let Some(dt_ms) = request.dt_ms {
+        if dt_ms < 0 {
+            return Err(anyhow!("dt_ms must be non-negative"));
+        }
+    }
+
+    for _ in 0..count {
+        if let Some(dt_ms) = request.dt_ms {
+            harness.advance_time(Duration::from_millis(dt_ms));
+        }
+        let cycle = harness.cycle();
+        if !cycle.errors.is_empty() {
+            let rendered = cycle
+                .errors
+                .iter()
+                .map(std::string::ToString::to_string)
+                .collect::<Vec<_>>()
+                .join("; ");
+            return Err(anyhow!("cycle failed: {rendered}"));
+        }
+    }
+
+    let values = watched_values(harness, request.watch.as_deref().unwrap_or(&[]));
+    Ok(json!({
+        "cycle_count": harness.cycle_count(),
+        "elapsed_ms": harness.current_time().as_millis(),
+        "values": values,
+    }))
+}
+
+fn watched_values(harness: &TestHarness, watch: &[String]) -> JsonValue {
+    let mut values = Map::new();
+    for name in watch {
+        let value = harness
+            .get_output(name)
+            .as_ref()
+            .map(value_to_json)
+            .unwrap_or(JsonValue::Null);
+        values.insert(name.clone(), value);
+    }
+    JsonValue::Object(values)
+}
+
+fn value_to_json(value: &Value) -> JsonValue {
+    match value {
+        Value::Bool(v) => json!(v),
+        Value::SInt(v) => json!(v),
+        Value::Int(v) => json!(v),
+        Value::DInt(v) => json!(v),
+        Value::LInt(v) => json!(v),
+        Value::USInt(v) => json!(v),
+        Value::UInt(v) => json!(v),
+        Value::UDInt(v) => json!(v),
+        Value::ULInt(v) => json!(v),
+        Value::Real(v) => json!(v),
+        Value::LReal(v) => json!(v),
+        Value::Byte(v) => json!(v),
+        Value::Word(v) => json!(v),
+        Value::DWord(v) => json!(v),
+        Value::LWord(v) => json!(v),
+        Value::Time(v) => json!({"type": "TIME", "ms": v.as_millis()}),
+        Value::LTime(v) => json!({"type": "LTIME", "ms": v.as_millis()}),
+        Value::Date(v) => json!({"type": "DATE", "ticks": v.ticks()}),
+        Value::LDate(v) => json!({"type": "LDATE", "nanos": v.nanos()}),
+        Value::Tod(v) => json!({"type": "TOD", "ticks": v.ticks()}),
+        Value::LTod(v) => json!({"type": "LTOD", "nanos": v.nanos()}),
+        Value::Dt(v) => json!({"type": "DT", "ticks": v.ticks()}),
+        Value::Ldt(v) => json!({"type": "LDT", "nanos": v.nanos()}),
+        Value::String(v) => json!(v.to_string()),
+        Value::WString(v) => json!(v),
+        Value::Char(v) => json!(char::from(*v).to_string()),
+        Value::WChar(v) => json!(std::char::from_u32(u32::from(*v))
+            .unwrap_or('\u{FFFD}')
+            .to_string()),
+        Value::Array(array) => JsonValue::Array(array.elements.iter().map(value_to_json).collect()),
+        Value::Struct(value) => {
+            let mut fields = Map::new();
+            for (name, field_value) in &value.fields {
+                fields.insert(name.to_string(), value_to_json(field_value));
+            }
+            json!({
+                "type": "STRUCT",
+                "type_name": value.type_name.to_string(),
+                "fields": fields,
+            })
+        }
+        Value::Enum(value) => json!({
+            "type": "ENUM",
+            "type_name": value.type_name.to_string(),
+            "variant": value.variant_name.to_string(),
+            "numeric": value.numeric_value,
+        }),
+        Value::Reference(reference) => json!({
+            "type": "REFERENCE",
+            "value": reference.as_ref().map(|entry| format!("{entry:?}")),
+        }),
+        Value::Instance(id) => json!({
+            "type": "INSTANCE",
+            "value": id.0,
+        }),
+        Value::Null => JsonValue::Null,
+    }
+}
+
+fn error_response(message: String) -> JsonValue {
+    json!({
+        "ok": false,
+        "error": message,
+    })
+}

--- a/crates/trust-runtime/tests/trust_harness_command.rs
+++ b/crates/trust-runtime/tests/trust_harness_command.rs
@@ -1,0 +1,131 @@
+use std::io::Write;
+use std::process::{Command, Stdio};
+
+use serde_json::{json, Value as JsonValue};
+
+fn timer_program() -> &'static str {
+    r#"
+PROGRAM Main
+VAR
+    ton_fb : TON;
+    q : BOOL;
+    et : TIME;
+END_VAR
+ton_fb(IN := TRUE, PT := T#100MS, Q => q, ET => et);
+END_PROGRAM
+"#
+}
+
+fn run_harness(requests: &[JsonValue]) -> (Vec<JsonValue>, String) {
+    let mut child = Command::new(env!("CARGO_BIN_EXE_trust-harness"))
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn trust-harness");
+
+    let mut stdin = child.stdin.take().expect("harness stdin");
+    for request in requests {
+        writeln!(
+            stdin,
+            "{}",
+            serde_json::to_string(request).expect("encode request")
+        )
+        .expect("write request");
+    }
+    drop(stdin);
+
+    let output = child.wait_with_output().expect("wait for trust-harness");
+    assert!(
+        output.status.success(),
+        "expected trust-harness success, stderr was:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout utf-8");
+    let responses = stdout
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .map(|line| serde_json::from_str::<JsonValue>(line).expect("decode response"))
+        .collect();
+    (
+        responses,
+        String::from_utf8(output.stderr).expect("stderr utf-8"),
+    )
+}
+
+#[test]
+fn trust_harness_cycle_dt_ms_advances_virtual_time() {
+    let (responses, stderr) = run_harness(&[
+        json!({
+            "cmd": "load",
+            "source": timer_program(),
+        }),
+        json!({
+            "cmd": "cycle",
+            "count": 10,
+            "dt_ms": 10,
+            "watch": ["q", "et"],
+        }),
+    ]);
+
+    assert_eq!(responses.len(), 2, "stderr was:\n{stderr}");
+    assert_eq!(responses[0]["ok"], json!(true));
+    assert_eq!(responses[1]["ok"], json!(true));
+    assert_eq!(responses[1]["data"]["values"]["q"], json!(true));
+    assert_eq!(
+        responses[1]["data"]["values"]["et"],
+        json!({"type": "TIME", "ms": 100})
+    );
+}
+
+#[test]
+fn trust_harness_cycle_without_dt_ms_keeps_time_frozen() {
+    let (responses, stderr) = run_harness(&[
+        json!({
+            "cmd": "load",
+            "source": timer_program(),
+        }),
+        json!({
+            "cmd": "cycle",
+            "count": 10,
+            "watch": ["q", "et"],
+        }),
+    ]);
+
+    assert_eq!(responses.len(), 2, "stderr was:\n{stderr}");
+    assert_eq!(responses[0]["ok"], json!(true));
+    assert_eq!(responses[1]["ok"], json!(true));
+    assert_eq!(responses[1]["data"]["values"]["q"], json!(false));
+    assert_eq!(
+        responses[1]["data"]["values"]["et"],
+        json!({"type": "TIME", "ms": 0})
+    );
+}
+
+#[test]
+fn trust_harness_rejects_negative_dt_ms() {
+    let (responses, stderr) = run_harness(&[
+        json!({
+            "cmd": "load",
+            "source": timer_program(),
+        }),
+        json!({
+            "cmd": "cycle",
+            "count": 1,
+            "dt_ms": -1,
+        }),
+    ]);
+
+    assert_eq!(responses.len(), 2, "stderr was:\n{stderr}");
+    assert_eq!(responses[0]["ok"], json!(true));
+    assert_eq!(responses[1]["ok"], json!(false));
+    assert!(
+        responses[1]["error"]
+            .as_str()
+            .expect("error string")
+            .contains("dt_ms"),
+        "expected dt_ms error, got: {}",
+        responses[1]
+    );
+}


### PR DESCRIPTION
## Summary
- add a lightweight `trust-harness` JSON-line binary for compiled ST test driving
- support `cycle.dt_ms` virtual-time advancement with negative-value rejection
- return typed `TIME`/`LTIME` watch values as JSON objects

## Tests
- CARGO_TARGET_DIR=/home/johannes/projects/trust-platform/target-harness cargo test -p trust-runtime --test trust_harness_command
- CARGO_TARGET_DIR=/home/johannes/projects/trust-platform/target-harness cargo test -p trust-runtime --test iec_timers timing_diagrams -- --exact

## Notes
- supersedes #31 with a clean harness-only implementation
- keeps `cycle()` itself unchanged; the new behavior is isolated to the CLI driver