### PR TITLE
chore(release): cut v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 
 ## [Unreleased]
 
-Target release: `v0.9.29`
+Target release: `v0.10.0`
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.9.29"
+version = "0.10.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/johannesPettersson80/trust-platform"

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trust-lsp",
-  "version": "0.9.29",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trust-lsp",
-      "version": "0.9.29",
+      "version": "0.10.0",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@vscode/codicons": "^0.0.44",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "truST LSP",
   "description": "truST LSP — IEC 61131-3 Structured Text language support",
   "icon": "icon.png",
-  "version": "0.9.29",
+  "version": "0.10.0",
   "publisher": "trust-platform",
   "license": "MIT OR Apache-2.0",
   "engines": {


### PR DESCRIPTION
## Summary
- bump workspace version to 0.10.0
- sync VS Code extension version metadata
- update the unreleased changelog target to v0.10.0

## Validation
- just fmt
- just clippy
- just test-all
- cargo test -p trust-runtime --test api_smoke
- cargo test -p trust-runtime --test debug_control
- cargo test -p trust-runtime --test complete_program
- cargo test -p trust-runtime --test runtime_reliability
- cd editors/vscode && npm run lint
- cd editors/vscode && npm run compile