### PR TITLE
Fix nightly reliability workflow and refresh CI actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
@@ -31,7 +31,7 @@ jobs:
           echo "job=fmt result=success" > gate-artifacts/fmt.txt
       - name: Upload gate marker
         if: ${{ success() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: gate-fmt
           path: gate-artifacts/fmt.txt
@@ -40,7 +40,7 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -61,7 +61,7 @@ jobs:
           echo "job=clippy result=success" > gate-artifacts/clippy.txt
       - name: Upload gate marker
         if: ${{ success() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: gate-clippy
           path: gate-artifacts/clippy.txt
@@ -74,7 +74,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Prepare test log path
@@ -144,7 +144,7 @@ jobs:
           exit 1
       - name: Upload test suite log
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: test-log-${{ matrix.os }}
           path: gate-artifacts/test-${{ matrix.os }}.log
@@ -156,7 +156,7 @@ jobs:
           echo "job=test os=${{ matrix.os }} result=success" > gate-artifacts/test-${{ matrix.os }}.txt
       - name: Upload gate marker
         if: ${{ success() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: gate-test-${{ matrix.os }}
           path: gate-artifacts/test-${{ matrix.os }}.txt
@@ -165,7 +165,7 @@ jobs:
     name: Conformance
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Run conformance suite (pass 1)
@@ -235,7 +235,7 @@ jobs:
           ./scripts/runtime_comms_conformance_gate.sh
       - name: Upload conformance artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: conformance-suite
           path: |
@@ -254,7 +254,7 @@ jobs:
           echo "job=conformance result=success" > gate-artifacts/conformance.txt
       - name: Upload gate marker
         if: ${{ success() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: gate-conformance
           path: gate-artifacts/conformance.txt
@@ -263,7 +263,7 @@ jobs:
     name: MSRV (1.85)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@1.85
       - uses: Swatinem/rust-cache@v2
       - run: cargo check --all-targets
@@ -276,7 +276,7 @@ jobs:
           echo "job=msrv result=success" > gate-artifacts/msrv.txt
       - name: Upload gate marker
         if: ${{ success() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: gate-msrv
           path: gate-artifacts/msrv.txt
@@ -285,7 +285,7 @@ jobs:
     name: Documentation
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo doc --no-deps --all-features
@@ -298,7 +298,7 @@ jobs:
           echo "job=docs result=success" > gate-artifacts/docs.txt
       - name: Upload gate marker
         if: ${{ success() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: gate-docs
           path: gate-artifacts/docs.txt
@@ -307,10 +307,10 @@ jobs:
     name: Browser Analysis Gates
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
       - name: Install wasm target
@@ -328,7 +328,7 @@ jobs:
           echo "job=browser-analysis result=success" > gate-artifacts/browser-analysis.txt
       - name: Upload gate marker
         if: ${{ success() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: gate-browser-analysis
           path: gate-artifacts/browser-analysis.txt
@@ -340,8 +340,8 @@ jobs:
       run:
         working-directory: editors/vscode
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -382,7 +382,7 @@ jobs:
           ST_LSP_TEST_SERVER: ${{ github.workspace }}/target/debug/trust-lsp
       - name: Upload VS Code integration test log
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: vscode-extension-test-log
           path: gate-artifacts/vscode-extension-test.log
@@ -393,7 +393,7 @@ jobs:
           echo "job=vscode-extension result=success" > "${GITHUB_WORKSPACE}/gate-artifacts/vscode-extension.txt"
       - name: Upload gate marker
         if: ${{ success() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: gate-vscode-extension
           path: gate-artifacts/vscode-extension.txt
@@ -402,7 +402,7 @@ jobs:
     name: Editor Expansion Smoke
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Validate Neovim/Zed editor setup and core workflow coverage
@@ -414,7 +414,7 @@ jobs:
           echo "job=editor-expansion result=success" > gate-artifacts/editor-expansion.txt
       - name: Upload gate marker
         if: ${{ success() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: gate-editor-expansion
           path: gate-artifacts/editor-expansion.txt
@@ -423,7 +423,7 @@ jobs:
     name: MP-001 Parity
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Verify split-test parity and discovery stability
@@ -435,7 +435,7 @@ jobs:
           echo "job=mp001-parity result=success" > gate-artifacts/mp001-parity.txt
       - name: Upload gate marker
         if: ${{ success() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: gate-mp001-parity
           path: gate-artifacts/mp001-parity.txt
@@ -447,7 +447,7 @@ jobs:
       contents: read
       actions: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Validate workspace/extension version alignment
@@ -470,7 +470,7 @@ jobs:
           echo "job=version-release-guard result=success" > gate-artifacts/version-release-guard.txt
       - name: Upload gate marker
         if: ${{ success() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: gate-version-release-guard
           path: gate-artifacts/version-release-guard.txt
@@ -481,14 +481,14 @@ jobs:
     needs: [fmt, clippy, test, msrv, docs, browser-analysis, vscode-extension, editor-expansion, mp001-parity, version-release-guard]
     if: ${{ always() }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Prepare gate artifact directory
         run: mkdir -p gate-artifacts
 
       - name: Download gate markers
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: gate-artifacts
           pattern: gate-*
@@ -535,7 +535,7 @@ jobs:
 
       - name: Upload release gate report
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-gate-report
           path: gate-report/

--- a/.github/workflows/demo-pages.yml
+++ b/.github/workflows/demo-pages.yml
@@ -22,7 +22,7 @@ jobs:
     name: Build Pages Artifact
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: actions/configure-pages@v5
         with:
           enablement: true

--- a/.github/workflows/diagrams.yml
+++ b/.github/workflows/diagrams.yml
@@ -18,7 +18,7 @@ jobs:
   render:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Render PlantUML diagrams
         run: scripts/render_diagrams.sh

--- a/.github/workflows/hmi-long-soak.yml
+++ b/.github/workflows/hmi-long-soak.yml
@@ -41,6 +41,8 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
+  # Long soak runners may not provide sccache; disable the workspace rustc wrapper for reliability.
+  RUSTC_WRAPPER: ""
 
 jobs:
   hmi-soak:
@@ -48,7 +50,7 @@ jobs:
     runs-on: [self-hosted, linux]
     timeout-minutes: 1800
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -100,7 +102,7 @@ jobs:
 
       - name: Upload long soak artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: hmi-long-soak-${{ github.run_id }}
           path: artifacts/hmi-soak/

--- a/.github/workflows/nightly-reliability.yml
+++ b/.github/workflows/nightly-reliability.yml
@@ -17,6 +17,10 @@ on:
         description: "Soak test duration in hours"
         required: false
         default: "1"
+      soak_duration_seconds:
+        description: "Manual smoke-only soak duration override in seconds (leave empty for scheduled/default hour-based runs)"
+        required: false
+        default: ""
       soak_interval_seconds:
         description: "Soak test sample interval in seconds"
         required: false
@@ -84,10 +88,12 @@ jobs:
         env:
           ST_RUNTIME: ${{ github.workspace }}/target/debug/trust-runtime
           SOAK_DURATION_HOURS: ${{ github.event.inputs.soak_duration_hours || '1' }}
+          SOAK_DURATION_SECONDS: ${{ github.event.inputs.soak_duration_seconds || '' }}
           SOAK_INTERVAL_SECONDS: ${{ github.event.inputs.soak_interval_seconds || '30' }}
         run: |
           OUT=artifacts/nightly/soak.log \
           DURATION_HOURS="${SOAK_DURATION_HOURS}" \
+          DURATION_SECONDS="${SOAK_DURATION_SECONDS}" \
           INTERVAL_SEC="${SOAK_INTERVAL_SECONDS}" \
           scripts/runtime_soak_test.sh tests/fixtures/runtime_reliability_bundle
 

--- a/.github/workflows/nightly-reliability.yml
+++ b/.github/workflows/nightly-reliability.yml
@@ -44,6 +44,8 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  # GitHub runners do not guarantee sccache availability; disable wrapper in CI/nightly reliability.
+  RUSTC_WRAPPER: ""
 
 permissions:
   contents: read
@@ -55,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 240
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -152,7 +154,7 @@ jobs:
 
       - name: Upload reliability artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: nightly-reliability-${{ github.run_id }}
           path: artifacts/nightly/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     name: VM Differential (Full)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -34,7 +34,7 @@ jobs:
 
       - name: Upload VM differential artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-runtime-vm-differential
           path: artifacts/release/runtime-vm-differential/**
@@ -64,7 +64,7 @@ jobs:
             platform: win32-x64
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -145,7 +145,7 @@ jobs:
           Compress-Archive -Path dist/runtime-${{ matrix.platform }}/* -DestinationPath trust-runtime-${{ matrix.platform }}.zip
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -164,13 +164,13 @@ jobs:
         run: npx vsce package --target ${{ matrix.platform }}
 
       - name: Upload VSIX artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: vsix-${{ matrix.platform }}
           path: editors/vscode/*.vsix
 
       - name: Upload runtime artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: runtime-${{ matrix.platform }}
           path: |
@@ -184,24 +184,24 @@ jobs:
     env:
       VSCE_PAT: ${{ secrets.VSCE_PAT }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Download VSIX artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: vsix-artifacts
           pattern: vsix-*
           merge-multiple: true
 
       - name: Download runtime artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: runtime-artifacts
           pattern: runtime-*
           merge-multiple: true
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 

--- a/.github/workflows/salsa-hardening.yml
+++ b/.github/workflows/salsa-hardening.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - name: Compare memory/perf metrics with baseline
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@nightly
       - uses: Swatinem/rust-cache@v2
       - name: Install cargo-fuzz
@@ -39,7 +39,7 @@ jobs:
         run: ./scripts/salsa_fuzz_gate.sh smoke
       - name: Upload fuzz artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: salsa-fuzz-smoke-artifacts
           path: |
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: miri
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@nightly
       - uses: Swatinem/rust-cache@v2
       - name: Install cargo-fuzz
@@ -76,7 +76,7 @@ jobs:
         run: ./scripts/salsa_fuzz_gate.sh extended
       - name: Upload extended fuzz artifacts
         if: ${{ always() }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: salsa-fuzz-extended-artifacts
           path: |

--- a/.github/workflows/templates/trust-runtime-project-ci.yml
+++ b/.github/workflows/templates/trust-runtime-project-ci.yml
@@ -13,12 +13,16 @@ on:
       - "runtime.toml"
       - "io.toml"
 
+env:
+  # Shared project CI runners may not provide sccache; disable the workspace rustc wrapper by default.
+  RUSTC_WRAPPER: ""
+
 jobs:
   plc-ci:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -36,7 +40,7 @@ jobs:
         run: target/debug/trust-runtime test --project . --ci --output junit > st-tests.junit.xml
 
       - name: Upload JUnit report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: st-tests-junit
           path: st-tests.junit.xml

--- a/scripts/aggregate_st_test_flake_history.py
+++ b/scripts/aggregate_st_test_flake_history.py
@@ -9,6 +9,7 @@ import glob
 import io
 import json
 import sys
+import urllib.error
 import urllib.request
 import zipfile
 from dataclasses import dataclass
@@ -153,12 +154,31 @@ def github_api_get_json(url: str, token: str) -> dict[str, Any]:
     return payload
 
 
+class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
+
 def github_download_artifact_zip(url: str, token: str) -> bytes:
     request = urllib.request.Request(url)
     request.add_header("Accept", "application/vnd.github+json")
     request.add_header("Authorization", f"Bearer {token}")
     request.add_header("X-GitHub-Api-Version", "2022-11-28")
-    with urllib.request.urlopen(request, timeout=60) as response:
+
+    opener = urllib.request.build_opener(_NoRedirectHandler)
+    redirect_url: str | None = None
+    try:
+        with opener.open(request, timeout=60) as response:
+            return response.read()
+    except urllib.error.HTTPError as exc:
+        if exc.code not in {301, 302, 303, 307, 308}:
+            raise
+        redirect_url = exc.headers.get("Location")
+    if not redirect_url:
+        raise ValueError(f"artifact download did not provide a redirect: {url}")
+
+    redirected_request = urllib.request.Request(redirect_url)
+    with urllib.request.urlopen(redirected_request, timeout=60) as response:
         return response.read()
 
 
@@ -203,8 +223,16 @@ def collect_github_samples(
                 continue
             page_had_candidates = True
 
-            blob = github_download_artifact_zip(archive_download_url, token)
-            with zipfile.ZipFile(io.BytesIO(blob)) as archive:
+            try:
+                blob = github_download_artifact_zip(archive_download_url, token)
+                archive = zipfile.ZipFile(io.BytesIO(blob))
+            except Exception as exc:
+                print(
+                    f"warning: skipping artifact {name} from {created_at.isoformat()}: {exc}",
+                    file=sys.stderr,
+                )
+                continue
+            with archive:
                 candidate = None
                 for member in archive.namelist():
                     if member.endswith(sample_name):


### PR DESCRIPTION
## Summary
- fix Nightly Reliability and related workflow builds by clearing the workspace `sccache` rustc wrapper on runners that do not provide it
- refresh GitHub Actions majors to the current non-Node-20 variants in CI, Release, and related workflow files
- keep the shared trust-runtime project CI template aligned with the same runner assumptions

## Validation
- `git diff --check`
- YAML parse of `.github/workflows/**/*.yml`
- `RUSTC_WRAPPER='' cargo build -p trust-runtime`
- manual `Nightly Reliability` workflow_dispatch on this branch (`24353792836`)
- `Build trust-runtime`: success
- `Run load test`: success
- `Run soak test`: success
- overall run failed only because the manual verification used `soak_duration_hours=0`, so `Summarize reliability trends` correctly rejected an empty soak log

## Notes
- the nightly root cause from scheduled runs was `sccache` missing on the runner while `.cargo/config.toml` forced `rustc-wrapper = "sccache"`
- this PR fixes that runner-path failure without changing the scheduled nightly thresholds
