### PR TITLE
fix(ci): batch resolve rust 1.95 clippy regressions

### DIFF
--- a/crates/trust-debug/src/adapter/stop_remote.rs
+++ b/crates/trust-debug/src/adapter/stop_remote.rs
@@ -71,11 +71,7 @@ fn should_emit_stop(
     breakpoints: &Arc<Mutex<HashMap<u32, u64>>>,
 ) -> bool {
     match stop.reason.as_str() {
-        "pause" | "entry" => {
-            if !pause_expected.swap(false, Ordering::SeqCst) {
-                return false;
-            }
-        }
+        "pause" | "entry" if !pause_expected.swap(false, Ordering::SeqCst) => return false,
         "breakpoint" | "step" => {
             pause_expected.store(false, Ordering::SeqCst);
         }

--- a/crates/trust-runtime/src/bin/trust-runtime/deploy/diffs.rs
+++ b/crates/trust-runtime/src/bin/trust-runtime/deploy/diffs.rs
@@ -129,10 +129,8 @@ fn diff_sources(previous_root: Option<&Path>, next_root: &Path) -> SourceDiff {
         match (prev.get(&key), next.get(&key)) {
             (None, Some(_)) => added.push(key),
             (Some(_), None) => removed.push(key),
-            (Some(prev_bytes), Some(next_bytes)) => {
-                if prev_bytes != next_bytes {
-                    modified.push(key);
-                }
+            (Some(prev_bytes), Some(next_bytes)) if prev_bytes != next_bytes => {
+                modified.push(key);
             }
             _ => {}
         }

--- a/crates/trust-runtime/src/harness/coerce.rs
+++ b/crates/trust-runtime/src/harness/coerce.rs
@@ -74,11 +74,7 @@ fn coerce_initializer_value_to_runtime_type(
             if target_array.dimensions != *dimensions {
                 target_array.dimensions = dimensions.clone();
             }
-            for (slot, element_value) in target_array
-                .elements
-                .iter_mut()
-                .zip(array.elements.into_iter())
-            {
+            for (slot, element_value) in target_array.elements.iter_mut().zip(array.elements) {
                 *slot =
                     coerce_initializer_value_to_type(element_value, *element, registry, profile)?;
             }

--- a/crates/trust-runtime/src/hmi/points.rs
+++ b/crates/trust-runtime/src/hmi/points.rs
@@ -142,13 +142,8 @@ fn widget_for_type(ty: &Type, writable: bool) -> &'static str {
         | Type::Class { .. }
         | Type::Interface { .. } => "tree",
         ty if ty.is_string() || ty.is_char() => "text",
-        ty if ty.is_numeric() || ty.is_bit_string() || ty.is_time() => {
-            if writable {
-                "slider"
-            } else {
-                "value"
-            }
-        }
+        ty if (ty.is_numeric() || ty.is_bit_string() || ty.is_time()) && writable => "slider",
+        ty if ty.is_numeric() || ty.is_bit_string() || ty.is_time() => "value",
         _ => "value",
     }
 }
@@ -283,4 +278,3 @@ fn now_unix_ms() -> u128 {
         .unwrap_or_default()
         .as_millis()
 }
-

--- a/crates/trust-runtime/src/runtime/vm/register_ir.rs
+++ b/crates/trust-runtime/src/runtime/vm/register_ir.rs
@@ -1354,41 +1354,37 @@ fn lowered_uses_complex_local_paths(module: &VmModule, program: &RegisterProgram
             RegisterInstr::LoadRef { ref_idx, .. }
             | RegisterInstr::LoadRefAddr { ref_idx, .. }
             | RegisterInstr::StoreRef { ref_idx, .. }
-            | RegisterInstr::CmpRefConstJumpIf { ref_idx, .. } => {
-                if uses_complex_local_ref(*ref_idx) {
-                    return true;
-                }
+            | RegisterInstr::CmpRefConstJumpIf { ref_idx, .. }
+                if uses_complex_local_ref(*ref_idx) =>
+            {
+                return true;
             }
             RegisterInstr::BinaryRefToRef {
                 left_ref_idx,
                 right_ref_idx,
                 dest_ref_idx,
                 ..
-            } => {
-                if uses_complex_local_ref(*left_ref_idx)
-                    || uses_complex_local_ref(*right_ref_idx)
-                    || uses_complex_local_ref(*dest_ref_idx)
-                {
-                    return true;
-                }
+            } if uses_complex_local_ref(*left_ref_idx)
+                || uses_complex_local_ref(*right_ref_idx)
+                || uses_complex_local_ref(*dest_ref_idx) =>
+            {
+                return true;
             }
             RegisterInstr::BinaryRefConstToRef {
                 left_ref_idx,
                 dest_ref_idx,
                 ..
-            } => {
-                if uses_complex_local_ref(*left_ref_idx) || uses_complex_local_ref(*dest_ref_idx) {
-                    return true;
-                }
+            } if uses_complex_local_ref(*left_ref_idx) || uses_complex_local_ref(*dest_ref_idx) => {
+                return true;
             }
             RegisterInstr::BinaryConstRefToRef {
                 right_ref_idx,
                 dest_ref_idx,
                 ..
-            } => {
-                if uses_complex_local_ref(*right_ref_idx) || uses_complex_local_ref(*dest_ref_idx) {
-                    return true;
-                }
+            } if uses_complex_local_ref(*right_ref_idx)
+                || uses_complex_local_ref(*dest_ref_idx) =>
+            {
+                return true;
             }
             _ => {}
         }

--- a/crates/trust-runtime/src/ui/input.rs
+++ b/crates/trust-runtime/src/ui/input.rs
@@ -155,21 +155,15 @@ pub(super) fn handle_prompt_key(
             state.prompt.clear_suggestions();
             return handle_prompt_submit(&input, client, state);
         }
-        KeyCode::Backspace => {
-            if state.prompt.cursor > 0 {
-                state.prompt.cursor -= 1;
-                state.prompt.input.remove(state.prompt.cursor);
-            }
+        KeyCode::Backspace if state.prompt.cursor > 0 => {
+            state.prompt.cursor -= 1;
+            state.prompt.input.remove(state.prompt.cursor);
         }
-        KeyCode::Left => {
-            if state.prompt.cursor > 0 {
-                state.prompt.cursor -= 1;
-            }
+        KeyCode::Left if state.prompt.cursor > 0 => {
+            state.prompt.cursor -= 1;
         }
-        KeyCode::Right => {
-            if state.prompt.cursor < state.prompt.input.len() {
-                state.prompt.cursor += 1;
-            }
+        KeyCode::Right if state.prompt.cursor < state.prompt.input.len() => {
+            state.prompt.cursor += 1;
         }
         KeyCode::Up => {
             if state.prompt.showing_suggestions {

--- a/crates/trust-runtime/src/web/ide/utils/analysis.rs
+++ b/crates/trust-runtime/src/web/ide/utils/analysis.rs
@@ -75,7 +75,7 @@ pub(in crate::web::ide) fn apply_text_edits(
     edits: &[trust_ide::rename::TextEdit],
 ) -> Result<String, IdeError> {
     let mut sorted = edits.to_vec();
-    sorted.sort_by(|a, b| b.range.start().cmp(&a.range.start()));
+    sorted.sort_by_key(|edit| std::cmp::Reverse(edit.range.start()));
 
     let mut output = text.to_string();
     for edit in sorted {

--- a/crates/trust-runtime/tests/io_multidriver_live.rs
+++ b/crates/trust-runtime/tests/io_multidriver_live.rs
@@ -92,11 +92,7 @@ fn start_mqtt_test_broker(
                                 sent_inbound = true;
                             }
                         }
-                        12 => {
-                            if write_mqtt_pingresp(&mut stream).is_err() {
-                                break;
-                            }
-                        }
+                        12 if write_mqtt_pingresp(&mut stream).is_err() => break,
                         14 => break,
                         _ => {}
                     }


### PR DESCRIPTION
## Summary
- batch-fix the Rust 1.95 Clippy regressions that GitHub stable exposed on main
- keep the fix scoped to lint-cleanup only, with no semantic/runtime behavior changes
- validate the branch locally with the GitHub-matching toolchain before merge

## Validation
- RUSTUP_TOOLCHAIN=1.95.0-aarch64-unknown-linux-gnu just fmt
- RUSTUP_TOOLCHAIN=1.95.0-aarch64-unknown-linux-gnu just clippy
- cargo test -p trust-runtime --test api_smoke
- cargo test -p trust-runtime --test debug_control
- cargo test -p trust-runtime --test complete_program
- cargo test -p trust-runtime --test runtime_reliability
- RUSTUP_TOOLCHAIN=1.95.0-aarch64-unknown-linux-gnu just test-all
