### PR TITLE
chore(architecture): enforce host-surface approved ports

### DIFF
--- a/crates/trust-runtime/src/control.rs
+++ b/crates/trust-runtime/src/control.rs
@@ -310,6 +310,14 @@ pub fn spawn_hmi_descriptor_watcher(state: Arc<ControlState>) {
     }
 }
 
+pub(crate) fn hmi_asset_project_root_port(state: &ControlState) -> Option<PathBuf> {
+    state.project_root.clone()
+}
+
+pub(crate) fn runtime_resource_name_port(state: &ControlState) -> SmolStr {
+    state.resource_name.clone()
+}
+
 pub(crate) fn handle_request_line(
     line: &str,
     state: &ControlState,

--- a/crates/trust-runtime/src/web/config_ui_routes.rs
+++ b/crates/trust-runtime/src/web/config_ui_routes.rs
@@ -1338,7 +1338,8 @@ fn resolve_runtime_target<'a>(
         return resolve_runtime_by_id(workspace, requested);
     }
 
-    let connected_via = control_state.resource_name.to_string();
+    let connected_via =
+        crate::control::runtime_resource_name_port(control_state.as_ref()).to_string();
     if !connected_via.is_empty() {
         if let Ok(runtime) = resolve_runtime_by_id(workspace, connected_via.as_str()) {
             return Ok(runtime);

--- a/crates/trust-runtime/src/web/runtime_cloud_routes/actions.rs
+++ b/crates/trust-runtime/src/web/runtime_cloud_routes/actions.rs
@@ -29,7 +29,7 @@ pub(super) fn handle_post_preflight(
                 return;
             }
         };
-    let local_runtime = ctx.control_state.resource_name.to_string();
+    let local_runtime = local_runtime_id(ctx);
     let (preflight, _ha_request, _known_targets) = runtime_cloud_preflight_for_action(
         &action,
         local_runtime.as_str(),
@@ -79,7 +79,7 @@ pub(super) fn handle_post_dispatch(
                 return;
             }
         };
-    let local_runtime = ctx.control_state.resource_name.to_string();
+    let local_runtime = local_runtime_id(ctx);
     let (preflight, ha_request, _known_targets) = runtime_cloud_preflight_for_action(
         &action,
         local_runtime.as_str(),

--- a/crates/trust-runtime/src/web/runtime_cloud_routes/config.rs
+++ b/crates/trust-runtime/src/web/runtime_cloud_routes/config.rs
@@ -19,10 +19,8 @@ pub(super) fn handle_get_config(request: tiny_http::Request, ctx: &RuntimeCloudR
         ctx.control_state.as_ref(),
         ctx.config_path,
     );
-    let snapshot = runtime_cloud_config_snapshot(
-        ctx.config_state.as_ref(),
-        ctx.control_state.resource_name.as_str(),
-    );
+    let snapshot =
+        runtime_cloud_config_snapshot(ctx.config_state.as_ref(), local_runtime_id(ctx).as_str());
     let response = Response::from_string(
         serde_json::to_string(&snapshot).unwrap_or_else(|_| "{}".to_string()),
     )

--- a/crates/trust-runtime/src/web/runtime_cloud_routes/control_proxy.rs
+++ b/crates/trust-runtime/src/web/runtime_cloud_routes/control_proxy.rs
@@ -64,7 +64,7 @@ pub(super) fn handle_post_control_proxy(
         return;
     }
 
-    let local_runtime = ctx.control_state.resource_name.to_string();
+    let local_runtime = local_runtime_id(ctx);
     let target_runtime = payload.target_runtime.trim().to_string();
     let action_type = proxy_action_type(kind, required_role);
     let action = RuntimeCloudActionRequest {

--- a/crates/trust-runtime/src/web/runtime_cloud_routes/io_proxy.rs
+++ b/crates/trust-runtime/src/web/runtime_cloud_routes/io_proxy.rs
@@ -29,7 +29,7 @@ fn runtime_cloud_io_preflight(
     api_version: &str,
     actor: &str,
 ) -> RuntimeCloudActionPreflight {
-    let local_runtime = ctx.control_state.resource_name.to_string();
+    let local_runtime = local_runtime_id(ctx);
     let payload = if action_type == "cfg_apply" {
         json!({ "params": {} })
     } else {
@@ -103,7 +103,7 @@ pub(super) fn handle_get_io_config(
     };
 
     let target_runtime = query_value(url, "target")
-        .unwrap_or_else(|| ctx.control_state.resource_name.to_string())
+        .unwrap_or_else(|| local_runtime_id(ctx))
         .trim()
         .to_string();
     if target_runtime.is_empty() {
@@ -131,7 +131,7 @@ pub(super) fn handle_get_io_config(
         return;
     }
 
-    let local_runtime = ctx.control_state.resource_name.to_string();
+    let local_runtime = local_runtime_id(ctx);
     if target_runtime == local_runtime {
         let response = match load_io_config(ctx.bundle_root) {
             Ok(config) => json_response(
@@ -277,7 +277,7 @@ pub(super) fn handle_post_io_config(
     }
 
     let io_request = payload.to_io_config_request();
-    let local_runtime = ctx.control_state.resource_name.to_string();
+    let local_runtime = local_runtime_id(ctx);
     if target_runtime == local_runtime {
         let response = match save_io_config(ctx.bundle_root, &io_request) {
             Ok(message) => json_response(200, json!({ "ok": true, "message": message })),

--- a/crates/trust-runtime/src/web/runtime_cloud_routes/links.rs
+++ b/crates/trust-runtime/src/web/runtime_cloud_routes/links.rs
@@ -84,7 +84,7 @@ pub(super) fn handle_post_link_transport(
         return;
     }
 
-    let local_runtime = ctx.control_state.resource_name.to_string();
+    let local_runtime = local_runtime_id(ctx);
     if source != local_runtime {
         let response = Response::from_string(
             serde_json::to_string(&RuntimeCloudLinkTransportSetResponse {

--- a/crates/trust-runtime/src/web/runtime_cloud_routes/mod.rs
+++ b/crates/trust-runtime/src/web/runtime_cloud_routes/mod.rs
@@ -36,6 +36,10 @@ pub(super) enum RuntimeCloudRouteOutcome {
     NotHandled(tiny_http::Request),
 }
 
+pub(super) fn local_runtime_id(ctx: &RuntimeCloudRouteContext<'_>) -> String {
+    crate::control::runtime_resource_name_port(ctx.control_state.as_ref()).to_string()
+}
+
 pub(super) fn handle_runtime_cloud_route(
     request: tiny_http::Request,
     method: &Method,

--- a/crates/trust-runtime/src/web/runtime_cloud_routes/state.rs
+++ b/crates/trust-runtime/src/web/runtime_cloud_routes/state.rs
@@ -32,8 +32,7 @@ pub(super) fn handle_get_state(request: tiny_http::Request, ctx: &RuntimeCloudRo
         return;
     }
     let now_ns = now_ns();
-    let local_runtime = ctx.control_state.resource_name.clone();
-    let local_runtime_text = local_runtime.to_string();
+    let local_runtime_text = local_runtime_id(ctx);
     let site = RUNTIME_CLOUD_DEFAULT_SITE;
     let mut peers_by_runtime = BTreeMap::<String, RuntimePresenceRecord>::new();
     for entry in ctx.discovery.snapshot() {
@@ -78,8 +77,8 @@ pub(super) fn handle_get_state(request: tiny_http::Request, ctx: &RuntimeCloudRo
             acting_on.push(peer.runtime_id.clone());
         }
     }
-    if !acting_on.iter().any(|id| id == local_runtime.as_str()) {
-        acting_on.push(local_runtime.to_string());
+    if !acting_on.iter().any(|id| id == local_runtime_text.as_str()) {
+        acting_on.push(local_runtime_text.clone());
     }
     let mode = if web_role.allows(AccessRole::Engineer) {
         UiMode::Edit
@@ -92,7 +91,7 @@ pub(super) fn handle_get_state(request: tiny_http::Request, ctx: &RuntimeCloudRo
         format!("local://{}", web_role.as_str())
     };
     let context = UiContext {
-        connected_via: local_runtime.to_string(),
+        connected_via: local_runtime_text.clone(),
         acting_on,
         site_scope: vec![site.to_string()],
         identity,

--- a/crates/trust-runtime/src/web/server.rs
+++ b/crates/trust-runtime/src/web/server.rs
@@ -140,7 +140,9 @@ pub fn start_web_server_with_mode(
                     auth_token: &auth_token,
                     pairing: pairing.as_deref(),
                     control_state: &control_state,
-                    bundle_root: &bundle_root,
+                    hmi_asset_root: bundle_root.clone().or_else(|| {
+                        crate::control::hmi_asset_project_root_port(control_state.as_ref())
+                    }),
                 },
             ) {
                 UiRouteOutcome::Handled => continue,

--- a/crates/trust-runtime/src/web/ui_routes.rs
+++ b/crates/trust-runtime/src/web/ui_routes.rs
@@ -9,7 +9,7 @@ pub(super) struct UiRouteContext<'a> {
     pub auth_token: &'a Arc<Mutex<Option<SmolStr>>>,
     pub pairing: Option<&'a PairingStore>,
     pub control_state: &'a Arc<ControlState>,
-    pub bundle_root: &'a Option<PathBuf>,
+    pub hmi_asset_root: Option<PathBuf>,
 }
 
 pub(super) enum UiRouteOutcome {
@@ -45,11 +45,7 @@ pub(super) fn handle_ui_route(
         return UiRouteOutcome::Handled;
     }
     if *method == Method::Get && url_path.starts_with("/hmi/assets/") {
-        let Some(project_root) = ctx
-            .bundle_root
-            .clone()
-            .or_else(|| ctx.control_state.project_root.clone())
-        else {
+        let Some(project_root) = ctx.hmi_asset_root else {
             let response = Response::from_string(
                 json!({ "ok": false, "error": "project root unavailable" }).to_string(),
             )

--- a/docs/internal/testing/checklists/full-architecture-refactor-program-checklist.md
+++ b/docs/internal/testing/checklists/full-architecture-refactor-program-checklist.md
@@ -15,7 +15,7 @@ This is the umbrella checklist. Individual execution boards own the detailed wor
 - [ ] `ARCHPROG-RULE-05` Do not merge a refactor branch that weakens an existing behavior lock, doctor rule, or generated-map check.
 - [x] `ARCHPROG-RULE-06` Use staged validation cadence: run focused tests and doctor checks during implementation, and reserve `just test-all` for merge/release readiness, board-completion gates, large cross-crate refactors, or rebases that touch shared APIs.
 - [x] `ARCHPROG-RULE-07` Do not claim production-ready secure remote MQTT until `DEPHYG-FOLLOW-01` implements explicit MQTT TLS/mTLS. Closed in `v0.24.7`: MQTT TLS/mTLS config and `rumqttc` TLS transport wiring are implemented, and remote plaintext remains gated by `allow_insecure_remote = true`.
-- [ ] `ARCHPROG-RULE-08` Do not treat the completed focused HIR mutation board as global HIR zero-silent-bug safety; all diagnostic-bearing HIR semantic decisions require the separate HIR zero-silent-bug board.
+- [x] `ARCHPROG-RULE-08` Do not treat the completed focused HIR mutation board as global HIR zero-silent-bug safety; all diagnostic-bearing HIR semantic decisions require the separate HIR zero-silent-bug board. Evidence: closed by the separate completed `hir-zero-silent-bug-refactor-checklist.md`, not by the earlier focused mutation board.
 
 ## Validation Cadence
 
@@ -37,7 +37,7 @@ This is the umbrella checklist. Individual execution boards own the detailed wor
 - [x] `ARCHPROG-BOARD-09` Diagram semantic enforcement is added before diagrams are trusted as acceptance evidence.
 - [ ] `ARCHPROG-BOARD-10` Runtime VM mutation hardening: `runtime-vm-mutation-hardening-execution-checklist.md`.
 - [ ] `ARCHPROG-BOARD-11` Unsafe/concurrency hardening: `unsafe-concurrency-hardening-execution-checklist.md`.
-- [ ] `ARCHPROG-BOARD-12` HIR zero-silent-bug refactor: `hir-zero-silent-bug-refactor-checklist.md`.
+- [x] `ARCHPROG-BOARD-12` HIR zero-silent-bug refactor: `hir-zero-silent-bug-refactor-checklist.md`.
 
 ## Recommended Order
 
@@ -56,14 +56,14 @@ This is the umbrella checklist. Individual execution boards own the detailed wor
 - [x] `ARCHPROG-B-03` Close HIR mutation gap for aggregate initializer validation.
 - [x] `ARCHPROG-B-04` Add mutation gate with zero unexplained survivors for the focused HIR shard.
 - [x] `ARCHPROG-B-05` Fix parser recovery bounded-scanner and fuzz/property tests.
-- [ ] `ARCHPROG-B-06` Close the full HIR zero-silent-bug architecture gap with semantic kernel, explicit resolver/validation outcomes, full semantic identity keys, and runtime/HIR declaration parity.
+- [x] `ARCHPROG-B-06` Close the full HIR zero-silent-bug architecture gap with semantic kernel, explicit resolver/validation outcomes, full semantic identity keys, and runtime/HIR declaration parity. Evidence: `hir-zero-silent-bug-refactor-checklist.md` is complete with final merge gate passed.
 
 ### Phase C - Runtime Boundary Policy Before Runtime Extraction
 
 - [x] `ARCHPROG-C-01` Classify runtime binary commands as product, UI product, conformance/benchmark, or workbench/dev.
-- [ ] `ARCHPROG-C-02` Classify `web`, `hmi`, `ui`, `control`, and `runtime_cloud` ownership.
+- [x] `ARCHPROG-C-02` Classify `web`, `hmi`, `ui`, `control`, and `runtime_cloud` ownership. Evidence: `runtime-host-surface-ownership-checklist.md` records owner categories in `xtask/config/full_map_policy.json`.
 - [x] `ARCHPROG-C-03` Add doctor rules for product/workbench command boundaries.
-- [ ] `ARCHPROG-C-04` Add doctor rules for host-surface forbidden imports and approved ports.
+- [x] `ARCHPROG-C-04` Add doctor rules for host-surface forbidden imports and approved ports. Evidence: `FULLMAP-CHECK-07` now enforces forbidden host-surface imports, owner categories, and direct web runtime-state bypass checks when approved ports are active.
 - [ ] `ARCHPROG-C-05` Freeze "no new top-level runtime module without subsystem decision note".
 
 ### Phase D - Runtime Core/Linux Host Split
@@ -118,4 +118,4 @@ This is the umbrella checklist. Individual execution boards own the detailed wor
 - [ ] `ARCHPROG-EXIT-10` Runtime VM mutation shard has zero unexplained survivors or a documented equivalent-mutant list.
 - [ ] `ARCHPROG-EXIT-11` `trust-runtime/src` host top-level module count is at or below the configured full-map cap after CLI, host-surface, and runtime-core boards complete, or a dated waiver names the next extraction branch.
 - [ ] `ARCHPROG-EXIT-12` Unsafe/concurrency register is complete and focused Miri/sanitizer/Loom/Valgrind evidence or exact blockers are attached.
-- [ ] `ARCHPROG-EXIT-13` HIR zero-silent-bug architecture is centralized, mutation-backed, doctor-guarded, and runtime declaration discovery is HIR catalog/parity driven.
+- [x] `ARCHPROG-EXIT-13` HIR zero-silent-bug architecture is centralized, mutation-backed, doctor-guarded, and runtime declaration discovery is HIR catalog/parity driven.

--- a/docs/internal/testing/checklists/runtime-host-surface-ownership-checklist.md
+++ b/docs/internal/testing/checklists/runtime-host-surface-ownership-checklist.md
@@ -1,6 +1,6 @@
 # Runtime Host Surface Ownership Checklist
 
-Status: First code-backed HMI runtime read/write control port landed; CHECK-07 still partial until the matching direct web runtime-state doctor rule is active
+Status: Phase 3 doctor rules active; Phase 4 named-file extraction remains open
 Owner: Runtime/web/HMI/control/cloud
 Scope: address audit F11 by defining and enforcing ownership for `web`, `hmi`, `ui`, `control`, and `runtime_cloud`.
 
@@ -15,9 +15,9 @@ Scope: address audit F11 by defining and enforcing ownership for `web`, `hmi`, `
 
 ## Phase 0 - Full-Map Prerequisite
 
-- [ ] `RTHOST-P0-001` Hard prerequisite: `architecture-doctor --full-map` MVP implements `FULLMAP-CHECK-07` for HMI/web/control/cloud ownership and forbidden edges before Phase 3 or Phase 4 starts. CHECK-07 exists and forbids the current `control -> web` / `hmi -> web` edge set, but `host_surface.approved_ports_active = false`; keep this open until Phase 2 ports are active or an owner-approved waiver is recorded.
+- [x] `RTHOST-P0-001` Hard prerequisite: `architecture-doctor --full-map` MVP implements `FULLMAP-CHECK-07` for HMI/web/control/cloud ownership and forbidden edges before Phase 3 or Phase 4 starts. CHECK-07 now enforces owner categories, forbidden `control -> web` / `hmi -> web` / `runtime_cloud -> web` implementation imports, and direct web runtime-state bypasses with `host_surface.approved_ports_active = true`.
 - [ ] `RTHOST-P0-002` If `FULLMAP-CHECK-07` is unavailable, record an owner-approved waiver with the local replacement rule, fixture, owner, and expiration date.
-- [ ] `RTHOST-P0-GATE-01` Do not claim `ARCHPROG-C-02` or `ARCHPROG-C-04` complete until `FULLMAP-CHECK-07` or its waiver is recorded.
+- [x] `RTHOST-P0-GATE-01` Do not claim `ARCHPROG-C-02` or `ARCHPROG-C-04` complete until `FULLMAP-CHECK-07` or its waiver is recorded.
 
 ## Stop Rules
 
@@ -74,14 +74,14 @@ Port design constraints:
 - HMI and runtime-cloud domain ports may depend on domain contracts and immutable runtime snapshots, but must not import `web`.
 - Control ports may own authorization/write side effects, but must not import web implementation types; the former `PairingStore` inversion was removed and must not be reintroduced.
 - Code-backed target landed on 2026-04-29: `crates/trust-runtime/src/control/hmi_runtime_ports.rs` owns the narrow HMI runtime read/write control port. `control/hmi_handlers_read.rs` and `control/hmi_handlers_write.rs` now delegate to it, preserving `hmi.schema.get`, `hmi.values.get`, `hmi.trends.get`, `hmi.alarms.get`, and `hmi.write` response contracts.
-- `host_surface.approved_ports_active` remains `false` until the matching direct web runtime-state doctor rule exists.
+- `host_surface.approved_ports_active` is now `true`: the matching direct web runtime-state doctor rule is active and fails web route code that reaches into runtime/control state fields instead of going through approved ports.
 
 ## Phase 3 - Doctor Rules
 
 - [x] `RTHOST-P3-001` Forbid `control -> web` implementation imports.
 - [x] `RTHOST-P3-002` Forbid `hmi -> web` implementation imports.
 - [x] `RTHOST-P3-003` Forbid `runtime_cloud -> web` implementation imports unless explicitly route-adapter scoped.
-- [ ] `RTHOST-P3-004` Forbid direct runtime state access from web routes when approved ports exist.
+- [x] `RTHOST-P3-004` Forbid direct runtime state access from web routes when approved ports exist.
 - [x] `RTHOST-P3-005` Require new HMI/web/control/cloud files to declare owner category in subsystem map or config.
 
 Phase 3 evidence captured on 2026-04-29:
@@ -89,7 +89,16 @@ Phase 3 evidence captured on 2026-04-29:
 - `xtask/config/full_map_policy.json` forbids production `control -> web`, `hmi -> web`, and `runtime_cloud -> web` implementation imports.
 - `xtask/config/full_map_policy.json` has `host_surface.owned_paths` owner categories for `control`, `hmi`, `web`, `ui`, and `runtime_cloud` roots/subtrees.
 - `xtask/src/full_map.rs` fixtures prove an unallowlisted host-surface import fails, test-only imports are ignored, `runtime_cloud -> web` fails, and host-surface files without owner category fail.
-- `RTHOST-P3-004` is unblocked by the first code-backed HMI runtime read/write port; next step is adding the matching doctor rule before setting `host_surface.approved_ports_active = true`.
+- `RTHOST-P3-004` is enforced by `xtask/src/full_map.rs`: web route files that directly access `ControlState` runtime fields such as `debug`, `metadata`, `io_snapshot`, `project_root`, `resource_name`, `hmi_descriptor`, or `historian` fail `FULLMAP-CHECK-07` when approved ports are active. `crates/trust-runtime/src/web/ui_routes.rs` now receives HMI asset roots through the control-owned `hmi_asset_project_root_port`, and runtime-cloud/config UI routes use `runtime_resource_name_port` instead of reading `ControlState` fields directly.
+
+Validation evidence captured on 2026-04-30:
+
+- `RUSTUP_TOOLCHAIN=1.95 cargo run -p xtask -- architecture-doctor --full-map` passes `FULLMAP-CHECK-07` with `approved ports active: true` and `direct web runtime-state bypass findings: 0`.
+- `RUSTUP_TOOLCHAIN=1.95 cargo test -p xtask host_surface -- --nocapture` passes the known-bad and no-bypass CHECK-07 fixtures.
+- `RUSTUP_TOOLCHAIN=1.95 cargo test -p trust-runtime --lib control::tests::hmi_ -- --nocapture` passes 17 HMI control-port tests.
+- `RUSTUP_TOOLCHAIN=1.95 cargo test -p trust-runtime --test web_io_config_integration runtime_cloud -- --nocapture` passes 40 runtime-cloud route/proxy tests.
+- `RUSTUP_TOOLCHAIN=1.95 cargo test -p trust-runtime --test hmi_readonly_integration -- --nocapture` passes 19 HMI route/asset integration tests.
+- `RUSTUP_TOOLCHAIN=1.95 cargo clippy -p xtask --all-targets -- -D warnings` and `RUSTUP_TOOLCHAIN=1.95 cargo clippy -p trust-runtime --all-targets -- -D warnings` pass for the touched crates.
 
 ## Phase 4 - Named-File Extraction
 

--- a/xtask/config/full_map_policy.json
+++ b/xtask/config/full_map_policy.json
@@ -117,7 +117,7 @@
     {"command": "Rollback", "module": "deploy", "handler": "deploy::run_rollback", "route_kind": "shared_handler", "owner": "runtime/deploy", "rationale": "Command::Rollback dispatches to deploy::run_rollback from the deployment module", "review_date": "2026-04-28"}
   ],
   "host_surface": {
-    "approved_ports_active": false,
+    "approved_ports_active": true,
     "owned_paths": [
       {"path_prefix": "crates/trust-runtime/src/control.rs", "category": "control_root", "owner": "runtime/control", "rationale": "control module root and ControlState live in the control boundary"},
       {"path_prefix": "crates/trust-runtime/src/control/", "category": "control_port", "owner": "runtime/control", "rationale": "control handlers and policy own HTTP-neutral command/query ports"},

--- a/xtask/src/full_map.rs
+++ b/xtask/src/full_map.rs
@@ -8,9 +8,9 @@ use serde::{Deserialize, Serialize};
 
 use crate::software_map::{
     CliActionSummary, DependencyHygieneSummary, DependencyPolicyEntry, DiagramEdge, DiagramFact,
-    ImportEdge, ModuleSummary, PackageSummary, ParserRecoverySummary, RuntimeRouteHandlerSummary,
-    SoftwareMap, SourceFileSummary, SourcePatternSummary, TargetSummary, ToolResult, ToolStatus,
-    UnsafeSummary, WorkspaceEdge,
+    HostSurfaceSummary, ImportEdge, ModuleSummary, PackageSummary, ParserRecoverySummary,
+    RuntimeRouteHandlerSummary, SoftwareMap, SourceFileSummary, SourcePatternSummary,
+    TargetSummary, ToolResult, ToolStatus, UnsafeSummary, WorkspaceEdge,
 };
 
 pub fn architecture_doctor_full_map(root: &Path) -> Result<()> {
@@ -404,6 +404,7 @@ fn build_software_map(root: &Path, policy: &FullMapPolicy) -> Result<SoftwareMap
         .cloned()
         .collect::<BTreeSet<_>>();
     map.import_edges = collect_import_edges(root, &known_import_modules)?;
+    map.host_surface = collect_host_surface_summary(root)?;
     map.runtime_cli_commands = parse_enum_variants(
         &fs::read_to_string(
             root.join("crates/trust-runtime/src/bin/trust-runtime/cli/commands.rs"),
@@ -1088,6 +1089,14 @@ fn check_host_surface_edges(map: &SoftwareMap, policy: &FullMapPolicy) -> FullMa
             )),
         }
     }
+    if policy.host_surface.approved_ports_active {
+        for bypass in &map.host_surface.direct_runtime_state_bypasses {
+            failures.push(format!(
+                "web route bypasses approved host-surface port at {}:{} ({})",
+                bypass.path, bypass.line, bypass.pattern
+            ));
+        }
+    }
 
     if failures.is_empty() {
         details.extend(vec![
@@ -1107,6 +1116,10 @@ fn check_host_surface_edges(map: &SoftwareMap, policy: &FullMapPolicy) -> FullMa
             format!(
                 "host-surface owner categories: {}",
                 categories.into_iter().collect::<Vec<_>>().join(", ")
+            ),
+            format!(
+                "direct web runtime-state bypass findings: {}",
+                map.host_surface.direct_runtime_state_bypasses.len()
             ),
         ]);
         if policy.host_surface.approved_ports_active {
@@ -1737,6 +1750,66 @@ fn collect_import_edges(root: &Path, known_modules: &BTreeSet<String>) -> Result
         }
     }
     Ok(edges)
+}
+
+fn collect_host_surface_summary(root: &Path) -> Result<HostSurfaceSummary> {
+    let web_root = root.join("crates/trust-runtime/src/web");
+    let mut files = Vec::new();
+    collect_source_files_inner(&web_root, &mut files)?;
+    let mut summary = HostSurfaceSummary::default();
+    for file in files {
+        if file.extension().and_then(|ext| ext.to_str()) != Some("rs") {
+            continue;
+        }
+        let rel = rel_path(root, &file);
+        if is_test_source_file(&rel) {
+            continue;
+        }
+        let source = fs::read_to_string(&file).unwrap_or_default();
+        for (idx, line) in source.lines().enumerate() {
+            let line = strip_line_comment(line);
+            if let Some(field) = direct_control_state_field_bypass(line) {
+                summary
+                    .direct_runtime_state_bypasses
+                    .push(SourcePatternSummary {
+                        path: rel.clone(),
+                        line: idx + 1,
+                        pattern: format!("ControlState.{field} direct web access"),
+                    });
+            }
+        }
+    }
+    Ok(summary)
+}
+
+fn direct_control_state_field_bypass(line: &str) -> Option<&'static str> {
+    const FORBIDDEN_FIELDS: &[&str] = &[
+        "debug",
+        "resource",
+        "metadata",
+        "sources",
+        "io_snapshot",
+        "pending_restart",
+        "metrics",
+        "events",
+        "settings",
+        "realtime_status",
+        "project_root",
+        "resource_name",
+        "io_health",
+        "debug_variables",
+        "hmi_live",
+        "hmi_descriptor",
+        "historian",
+    ];
+    for field in FORBIDDEN_FIELDS {
+        let direct = format!("control_state.{field}");
+        let context = format!("control_state.as_ref().{field}");
+        if line.contains(&direct) || line.contains(&context) {
+            return Some(field);
+        }
+    }
+    None
 }
 
 fn collect_unsafe_summary(root: &Path, policy: &FullMapPolicy) -> UnsafeSummary {
@@ -2679,6 +2752,56 @@ mod tests {
             .iter()
             .any(|detail| detail
                 .contains("crates/trust-runtime/src/control.rs' has no owner category")));
+    }
+
+    #[test]
+    fn known_bad_web_route_direct_runtime_state_bypass_fails_when_ports_active() {
+        let mut map = base_map();
+        map.host_surface
+            .direct_runtime_state_bypasses
+            .push(SourcePatternSummary {
+                path: "crates/trust-runtime/src/web/ui_routes.rs".to_string(),
+                line: 51,
+                pattern: "ControlState.project_root direct web access".to_string(),
+            });
+        let mut policy = base_policy();
+        policy.host_surface.approved_ports_active = true;
+
+        let check = check_host_surface_edges(&map, &policy);
+
+        assert!(check.is_fail());
+        assert!(check
+            .details
+            .iter()
+            .any(|detail| detail.contains("bypasses approved host-surface port")));
+    }
+
+    #[test]
+    fn host_surface_ports_active_passes_without_direct_runtime_state_bypass() {
+        let mut policy = base_policy();
+        policy.host_surface.approved_ports_active = true;
+
+        let check = check_host_surface_edges(&base_map(), &policy);
+
+        assert_eq!(check.status, CheckStatus::Pass);
+        assert!(check
+            .details
+            .iter()
+            .any(|detail| detail.contains("direct web runtime-state bypass findings: 0")));
+    }
+
+    #[test]
+    fn direct_control_state_field_bypass_detects_runtime_state_fields() {
+        assert_eq!(
+            direct_control_state_field_bypass("ctx.control_state.project_root.clone()"),
+            Some("project_root")
+        );
+        assert_eq!(
+            direct_control_state_field_bypass(
+                "dispatch_control_request(payload, control_state, None)"
+            ),
+            None
+        );
     }
 
     #[test]

--- a/xtask/src/software_map.rs
+++ b/xtask/src/software_map.rs
@@ -16,6 +16,7 @@ pub struct SoftwareMap {
     pub runtime_cli_actions: Vec<CliActionSummary>,
     pub runtime_bin_modules: Vec<String>,
     pub runtime_route_handlers: Vec<RuntimeRouteHandlerSummary>,
+    pub host_surface: HostSurfaceSummary,
     pub parser_recovery: ParserRecoverySummary,
     pub dependency_hygiene: DependencyHygieneSummary,
     pub unsafe_summary: UnsafeSummary,
@@ -78,6 +79,11 @@ pub struct RuntimeRouteHandlerSummary {
     pub handler: String,
     pub path: String,
     pub line: usize,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct HostSurfaceSummary {
+    pub direct_runtime_state_bypasses: Vec<SourcePatternSummary>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
@@ -165,7 +171,7 @@ impl ToolStatus {
 impl SoftwareMap {
     pub fn new(workspace_root: impl Into<String>) -> Self {
         Self {
-            schema_version: 4,
+            schema_version: 5,
             workspace_root: workspace_root.into(),
             generated_by: "cargo xtask architecture-doctor --full-map".to_string(),
             packages: Vec::new(),
@@ -179,6 +185,7 @@ impl SoftwareMap {
             runtime_cli_actions: Vec::new(),
             runtime_bin_modules: Vec::new(),
             runtime_route_handlers: Vec::new(),
+            host_surface: HostSurfaceSummary::default(),
             parser_recovery: ParserRecoverySummary::default(),
             dependency_hygiene: DependencyHygieneSummary::default(),
             unsafe_summary: UnsafeSummary::default(),
@@ -249,6 +256,14 @@ impl SoftwareMap {
                 .then_with(|| left.line.cmp(&right.line))
         });
         self.runtime_route_handlers.dedup();
+        self.host_surface
+            .direct_runtime_state_bypasses
+            .sort_by(|left, right| {
+                left.path
+                    .cmp(&right.path)
+                    .then_with(|| left.line.cmp(&right.line))
+                    .then_with(|| left.pattern.cmp(&right.pattern))
+            });
         self.parser_recovery.bounded_scan_helpers.sort();
         self.parser_recovery.bounded_scan_helpers.dedup();
         self.parser_recovery
@@ -306,7 +321,7 @@ mod tests {
         let reverse = sample_map(true).to_stable_json().unwrap();
 
         assert_eq!(forward, reverse);
-        assert!(forward.contains("\"schema_version\": 4"));
+        assert!(forward.contains("\"schema_version\": 5"));
         assert!(forward.contains("\"status\": \"not_run\""));
     }
 


### PR DESCRIPTION
## Summary
- activate host-surface approved-port enforcement in FULLMAP-CHECK-07
- route web HMI/runtime-cloud access through control-owned runtime name and HMI asset root ports
- update architecture checklists with validation evidence

## Validation
- RUSTUP_TOOLCHAIN=1.95 just fmt
- RUSTUP_TOOLCHAIN=1.95 cargo check -p trust-runtime --all-targets
- RUSTUP_TOOLCHAIN=1.95 cargo test -p xtask host_surface -- --nocapture
- RUSTUP_TOOLCHAIN=1.95 cargo test -p xtask -- --nocapture
- RUSTUP_TOOLCHAIN=1.95 cargo run -p xtask -- architecture-doctor --full-map
- RUSTUP_TOOLCHAIN=1.95 cargo test -p trust-runtime --lib control::tests::hmi_ -- --nocapture
- RUSTUP_TOOLCHAIN=1.95 cargo test -p trust-runtime --test web_io_config_integration runtime_cloud -- --nocapture
- RUSTUP_TOOLCHAIN=1.95 cargo test -p trust-runtime --test hmi_readonly_integration -- --nocapture
- RUSTUP_TOOLCHAIN=1.95 cargo clippy -p xtask --all-targets -- -D warnings
- RUSTUP_TOOLCHAIN=1.95 cargo clippy -p trust-runtime --all-targets -- -D warnings
- RUSTUP_TOOLCHAIN=1.95 cargo clippy --all-targets --all-features -- -D warnings
