### PR TITLE
chore(architecture): route web control dispatch through port

### DIFF
--- a/crates/trust-runtime/src/control.rs
+++ b/crates/trust-runtime/src/control.rs
@@ -318,6 +318,20 @@ pub(crate) fn runtime_resource_name_port(state: &ControlState) -> SmolStr {
     state.resource_name.clone()
 }
 
+pub(crate) fn dispatch_web_control_request_port(
+    mut payload: serde_json::Value,
+    state: &ControlState,
+    client: Option<&str>,
+    request_token: Option<&str>,
+) -> ControlResponse {
+    if payload.get("auth").is_none() {
+        if let Some(token) = request_token {
+            payload["auth"] = serde_json::Value::String(token.to_string());
+        }
+    }
+    handle_request_value(payload, state, client)
+}
+
 pub(crate) fn handle_request_line(
     line: &str,
     state: &ControlState,

--- a/crates/trust-runtime/src/web.rs
+++ b/crates/trust-runtime/src/web.rs
@@ -24,7 +24,7 @@ use crate::config::{
     load_system_io_config, IoConfig, IoDriverConfig, RuntimeCloudProfile, RuntimeCloudWanAllowRule,
     RuntimeConfig, WebAuthMode, WebConfig,
 };
-use crate::control::{handle_request_value, ControlState};
+use crate::control::ControlState;
 use crate::debug::dap::format_value;
 use crate::discovery::DiscoveryState;
 use crate::error::RuntimeError;

--- a/crates/trust-runtime/src/web/auth_helpers.rs
+++ b/crates/trust-runtime/src/web/auth_helpers.rs
@@ -71,17 +71,12 @@ pub(super) fn auth_error_response(error: &str) -> Response<std::io::Cursor<Vec<u
 }
 
 pub(super) fn dispatch_control_request(
-    mut payload: serde_json::Value,
+    payload: serde_json::Value,
     control_state: &ControlState,
     client: Option<&str>,
     request_token: Option<&str>,
 ) -> crate::control::ControlResponse {
-    if payload.get("auth").is_none() {
-        if let Some(token) = request_token {
-            payload["auth"] = serde_json::Value::String(token.to_string());
-        }
-    }
-    handle_request_value(payload, control_state, client)
+    crate::control::dispatch_web_control_request_port(payload, control_state, client, request_token)
 }
 
 pub(super) fn ide_session_token(request: &tiny_http::Request) -> Option<String> {

--- a/crates/trust-runtime/src/web/runtime_cloud_state/config.rs
+++ b/crates/trust-runtime/src/web/runtime_cloud_state/config.rs
@@ -224,10 +224,11 @@ pub(in crate::web) fn runtime_cloud_config_reconcile_once(
         "request_id": format!("cfg-agent-{desired_revision}"),
         "params": desired,
     });
-    let control_response = handle_request_value(
+    let control_response = dispatch_control_request(
         control_payload,
         control_state,
         Some("runtime-cloud-config-agent"),
+        None,
     );
     let response_value = serde_json::to_value(control_response).unwrap_or_else(
         |_| json!({ "ok": false, "error": "config apply response serialization failed" }),

--- a/crates/trust-runtime/src/web/ui_routes.rs
+++ b/crates/trust-runtime/src/web/ui_routes.rs
@@ -367,12 +367,13 @@ pub(super) fn handle_ui_route(
         return UiRouteOutcome::Handled;
     }
     if *method == Method::Get && url == "/hmi/export.json" {
-        let schema_response = handle_request_value(
+        let schema_response = dispatch_control_request(
             json!({
                 "id": 1_u64,
                 "type": "hmi.schema.get"
             }),
             ctx.control_state,
+            None,
             None,
         );
         let schema_payload =

--- a/docs/internal/testing/checklists/runtime-host-surface-ownership-checklist.md
+++ b/docs/internal/testing/checklists/runtime-host-surface-ownership-checklist.md
@@ -1,6 +1,6 @@
 # Runtime Host Surface Ownership Checklist
 
-Status: Phase 3 doctor rules active; Phase 4 named-file extraction remains open
+Status: Phase 3 doctor rules active; Phase 4 adapter port narrowing in progress
 Owner: Runtime/web/HMI/control/cloud
 Scope: address audit F11 by defining and enforcing ownership for `web`, `hmi`, `ui`, `control`, and `runtime_cloud`.
 
@@ -122,7 +122,7 @@ Named-file move table from `RTHOST-P1-008`:
 
 - [x] `RTHOST-P4-001` Replace the template row above with reviewed named-file rows from `RTHOST-P1-008`.
 - [x] `RTHOST-P4-002` For every `move` or `split` row, record destination module, owner, public API change, behavior-lock tests, and rollback plan.
-- [ ] `RTHOST-P4-003` For every `adapter-only` web route row, replace direct domain/runtime access with approved control/HMI/cloud ports.
+- [x] `RTHOST-P4-003` For every `adapter-only` web route row, replace direct domain/runtime access with approved control/HMI/cloud ports. Evidence: web route/control helpers now use `dispatch_web_control_request_port`, `runtime_resource_name_port`, and `hmi_asset_project_root_port`; `FULLMAP-CHECK-07` fails direct web `handle_request_value` dispatch and direct runtime-state field access when approved ports are active.
 - [ ] `RTHOST-P4-004` For every runtime-cloud route/state row, replace direct runtime execution ownership with runtime-cloud projection contracts.
 - [ ] `RTHOST-P4-005` For every duplicated DTO/schema/auth/write-check row, identify the canonical owner before deleting duplicates.
 - [ ] `RTHOST-P4-006` Keep browser assets and websocket details in web; any browser-visible row requires Playwright evidence in the implementation branch.
@@ -130,6 +130,14 @@ Named-file move table from `RTHOST-P1-008`:
 - [x] `RTHOST-P4-008` Decide exact action for `crates/trust-runtime/src/control/hmi_handlers*.rs`: keep HTTP-neutral control handlers, with runtime value read/write access delegated to `control/hmi_runtime_ports.rs`; HMI schema/contracts stay in `hmi`.
 - [ ] `RTHOST-P4-009` Decide exact action for `crates/trust-runtime/src/runtime_cloud/` files and `crates/trust-runtime/src/web/runtime_cloud_*` route/state files.
 - [x] `RTHOST-P4-010` Add the reviewed named-file move table to this checklist before code movement.
+
+Phase 4 adapter-port evidence captured on 2026-04-30:
+
+- `crates/trust-runtime/src/control.rs::dispatch_web_control_request_port` is the approved control-owned bridge for web routes that need authenticated local control dispatch.
+- `crates/trust-runtime/src/web/auth_helpers.rs::dispatch_control_request` now delegates to the control-owned port instead of calling `handle_request_value` directly.
+- `crates/trust-runtime/src/web/ui_routes.rs` `/hmi/export.json` and `crates/trust-runtime/src/web/runtime_cloud_state/config.rs` config-agent apply flow now use the approved web dispatch helper.
+- `xtask/src/full_map.rs` records `direct web control-dispatch bypass findings: 0` and has a known-bad CHECK-07 fixture for direct web `handle_request_value` dispatch.
+- Validation: `RUSTUP_TOOLCHAIN=1.95 cargo run -p xtask -- architecture-doctor --full-map`, `RUSTUP_TOOLCHAIN=1.95 cargo test -p xtask direct_control_dispatch -- --nocapture`, `RUSTUP_TOOLCHAIN=1.95 cargo test -p trust-runtime --test web_io_config_integration runtime_cloud_config_agent -- --nocapture`, and `RUSTUP_TOOLCHAIN=1.95 cargo test -p trust-runtime --test hmi_readonly_integration hmi_standalone_export -- --nocapture` pass.
 
 ## Phase 5 - Tests
 

--- a/xtask/src/full_map.rs
+++ b/xtask/src/full_map.rs
@@ -1096,6 +1096,12 @@ fn check_host_surface_edges(map: &SoftwareMap, policy: &FullMapPolicy) -> FullMa
                 bypass.path, bypass.line, bypass.pattern
             ));
         }
+        for bypass in &map.host_surface.direct_control_dispatch_bypasses {
+            failures.push(format!(
+                "web route bypasses approved control-dispatch port at {}:{} ({})",
+                bypass.path, bypass.line, bypass.pattern
+            ));
+        }
     }
 
     if failures.is_empty() {
@@ -1120,6 +1126,10 @@ fn check_host_surface_edges(map: &SoftwareMap, policy: &FullMapPolicy) -> FullMa
             format!(
                 "direct web runtime-state bypass findings: {}",
                 map.host_surface.direct_runtime_state_bypasses.len()
+            ),
+            format!(
+                "direct web control-dispatch bypass findings: {}",
+                map.host_surface.direct_control_dispatch_bypasses.len()
             ),
         ]);
         if policy.host_surface.approved_ports_active {
@@ -1777,9 +1787,23 @@ fn collect_host_surface_summary(root: &Path) -> Result<HostSurfaceSummary> {
                         pattern: format!("ControlState.{field} direct web access"),
                     });
             }
+            if direct_control_dispatch_bypass(line) {
+                summary
+                    .direct_control_dispatch_bypasses
+                    .push(SourcePatternSummary {
+                        path: rel.clone(),
+                        line: idx + 1,
+                        pattern: "handle_request_value direct web dispatch".to_string(),
+                    });
+            }
         }
     }
     Ok(summary)
+}
+
+fn direct_control_dispatch_bypass(line: &str) -> bool {
+    line.contains("handle_request_value(")
+        || line.contains("use crate::control::handle_request_value")
 }
 
 fn direct_control_state_field_bypass(line: &str) -> Option<&'static str> {
@@ -2777,6 +2801,28 @@ mod tests {
     }
 
     #[test]
+    fn known_bad_web_route_direct_control_dispatch_bypass_fails_when_ports_active() {
+        let mut map = base_map();
+        map.host_surface
+            .direct_control_dispatch_bypasses
+            .push(SourcePatternSummary {
+                path: "crates/trust-runtime/src/web/auth_helpers.rs".to_string(),
+                line: 82,
+                pattern: "handle_request_value direct web dispatch".to_string(),
+            });
+        let mut policy = base_policy();
+        policy.host_surface.approved_ports_active = true;
+
+        let check = check_host_surface_edges(&map, &policy);
+
+        assert!(check.is_fail());
+        assert!(check
+            .details
+            .iter()
+            .any(|detail| detail.contains("bypasses approved control-dispatch port")));
+    }
+
+    #[test]
     fn host_surface_ports_active_passes_without_direct_runtime_state_bypass() {
         let mut policy = base_policy();
         policy.host_surface.approved_ports_active = true;
@@ -2788,6 +2834,10 @@ mod tests {
             .details
             .iter()
             .any(|detail| detail.contains("direct web runtime-state bypass findings: 0")));
+        assert!(check
+            .details
+            .iter()
+            .any(|detail| detail.contains("direct web control-dispatch bypass findings: 0")));
     }
 
     #[test]
@@ -2802,6 +2852,19 @@ mod tests {
             ),
             None
         );
+    }
+
+    #[test]
+    fn direct_control_dispatch_bypass_detects_handle_request_value() {
+        assert!(direct_control_dispatch_bypass(
+            "let response = handle_request_value(payload, state, client);"
+        ));
+        assert!(direct_control_dispatch_bypass(
+            "use crate::control::handle_request_value;"
+        ));
+        assert!(!direct_control_dispatch_bypass(
+            "let response = dispatch_control_request(payload, state, client, token);"
+        ));
     }
 
     #[test]

--- a/xtask/src/software_map.rs
+++ b/xtask/src/software_map.rs
@@ -84,6 +84,7 @@ pub struct RuntimeRouteHandlerSummary {
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
 pub struct HostSurfaceSummary {
     pub direct_runtime_state_bypasses: Vec<SourcePatternSummary>,
+    pub direct_control_dispatch_bypasses: Vec<SourcePatternSummary>,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
@@ -171,7 +172,7 @@ impl ToolStatus {
 impl SoftwareMap {
     pub fn new(workspace_root: impl Into<String>) -> Self {
         Self {
-            schema_version: 5,
+            schema_version: 6,
             workspace_root: workspace_root.into(),
             generated_by: "cargo xtask architecture-doctor --full-map".to_string(),
             packages: Vec::new(),
@@ -264,6 +265,14 @@ impl SoftwareMap {
                     .then_with(|| left.line.cmp(&right.line))
                     .then_with(|| left.pattern.cmp(&right.pattern))
             });
+        self.host_surface
+            .direct_control_dispatch_bypasses
+            .sort_by(|left, right| {
+                left.path
+                    .cmp(&right.path)
+                    .then_with(|| left.line.cmp(&right.line))
+                    .then_with(|| left.pattern.cmp(&right.pattern))
+            });
         self.parser_recovery.bounded_scan_helpers.sort();
         self.parser_recovery.bounded_scan_helpers.dedup();
         self.parser_recovery
@@ -321,7 +330,7 @@ mod tests {
         let reverse = sample_map(true).to_stable_json().unwrap();
 
         assert_eq!(forward, reverse);
-        assert!(forward.contains("\"schema_version\": 5"));
+        assert!(forward.contains("\"schema_version\": 6"));
         assert!(forward.contains("\"status\": \"not_run\""));
     }
 


### PR DESCRIPTION
## Summary
- add a control-owned approved dispatch port for authenticated web control requests
- migrate web HMI export and runtime-cloud config-agent apply paths off direct handle_request_value dispatch
- extend FULLMAP-CHECK-07 with a known-bad direct control-dispatch bypass rule and mark RTHOST-P4-003 complete

## Validation
- RUSTUP_TOOLCHAIN=1.95 just fmt
- RUSTUP_TOOLCHAIN=1.95 cargo test -p xtask direct_control_dispatch -- --nocapture
- RUSTUP_TOOLCHAIN=1.95 cargo test -p xtask host_surface -- --nocapture
- RUSTUP_TOOLCHAIN=1.95 cargo run -p xtask -- architecture-doctor --full-map
- RUSTUP_TOOLCHAIN=1.95 cargo test -p trust-runtime --test web_io_config_integration runtime_cloud_config_agent -- --nocapture
- RUSTUP_TOOLCHAIN=1.95 cargo test -p trust-runtime --test hmi_readonly_integration hmi_standalone_export -- --nocapture
- RUSTUP_TOOLCHAIN=1.95 cargo clippy -p xtask -p trust-runtime --all-targets -- -D warnings
- RUSTUP_TOOLCHAIN=1.95 cargo test -p xtask -- --nocapture
- pre-commit hook with RUSTUP_TOOLCHAIN=1.95: fmt + cargo clippy --all-targets --all-features -- -D warnings
