### PR TITLE
chore(architecture): move runtime cloud profile policy

### DIFF
--- a/crates/trust-runtime/src/runtime_cloud/mod.rs
+++ b/crates/trust-runtime/src/runtime_cloud/mod.rs
@@ -15,5 +15,6 @@
 pub mod contracts;
 pub mod ha;
 pub mod keyspace;
+pub(crate) mod profile_policy;
 pub mod projection;
 pub mod routing;

--- a/crates/trust-runtime/src/runtime_cloud/profile_policy.rs
+++ b/crates/trust-runtime/src/runtime_cloud/profile_policy.rs
@@ -1,4 +1,4 @@
-//! Runtime-cloud profile policy evaluation for web handlers.
+//! Runtime-cloud profile, transport, and WAN allowlist policy evaluation.
 
 #![allow(missing_docs)]
 
@@ -12,7 +12,7 @@ use crate::runtime_cloud::routing::{
 
 const RUNTIME_CLOUD_DEFAULT_SITE: &str = "default-site";
 
-pub(super) fn runtime_cloud_apply_profile_policy(
+pub(crate) fn runtime_cloud_apply_profile_policy(
     mut preflight: RuntimeCloudActionPreflight,
     action: &RuntimeCloudActionRequest,
     targets: &BTreeMap<String, RuntimeCloudTargetStatus>,
@@ -65,7 +65,7 @@ pub(super) fn runtime_cloud_apply_profile_policy(
     preflight
 }
 
-pub(super) fn runtime_cloud_profile_precondition(
+pub(crate) fn runtime_cloud_profile_precondition(
     profile: RuntimeCloudProfile,
     auth_mode: WebAuthMode,
     web_tls_enabled: bool,

--- a/crates/trust-runtime/src/web.rs
+++ b/crates/trust-runtime/src/web.rs
@@ -39,6 +39,9 @@ use crate::runtime_cloud::ha::{
     RuntimeCloudHaDispatchGate, RuntimeCloudHaDispatchRecord, RuntimeCloudHaDispatchTicket,
     RuntimeCloudHaRequest,
 };
+use crate::runtime_cloud::profile_policy::{
+    runtime_cloud_apply_profile_policy, runtime_cloud_profile_precondition,
+};
 use crate::runtime_cloud::projection::{
     presence_record_from_observation, project_runtime_cloud_state, ChannelState, ChannelType,
     FleetEdge, PresenceThresholds, RuntimeCloudUiState, RuntimePeerObservation,
@@ -67,7 +70,6 @@ pub mod pairing {
 }
 mod runtime_cloud_dispatch;
 mod runtime_cloud_helpers;
-mod runtime_cloud_policy;
 mod runtime_cloud_routes;
 mod runtime_cloud_state;
 mod server;
@@ -92,9 +94,6 @@ use runtime_cloud_dispatch::{
     runtime_cloud_target_web_base_url, RuntimeCloudPreflightPolicy,
 };
 use runtime_cloud_helpers::*;
-use runtime_cloud_policy::{
-    runtime_cloud_apply_profile_policy, runtime_cloud_profile_precondition,
-};
 use runtime_cloud_routes::{
     handle_runtime_cloud_route, RuntimeCloudRouteContext, RuntimeCloudRouteOutcome,
 };

--- a/crates/trust-runtime/tests/runtime_cloud_architecture.rs
+++ b/crates/trust-runtime/tests/runtime_cloud_architecture.rs
@@ -11,6 +11,7 @@ fn runtime_cloud_core_modules_do_not_import_transport_layers() {
     let sources = [
         "src/runtime_cloud/contracts.rs",
         "src/runtime_cloud/ha.rs",
+        "src/runtime_cloud/profile_policy.rs",
         "src/runtime_cloud/projection.rs",
         "src/runtime_cloud/routing.rs",
     ];

--- a/docs/internal/testing/checklists/runtime-host-surface-ownership-checklist.md
+++ b/docs/internal/testing/checklists/runtime-host-surface-ownership-checklist.md
@@ -1,6 +1,6 @@
 # Runtime Host Surface Ownership Checklist
 
-Status: Phase 3 doctor rules active; Phase 4 adapter port narrowing in progress
+Status: Phase 3 doctor rules active; Phase 4 runtime-cloud projection extraction in progress
 Owner: Runtime/web/HMI/control/cloud
 Scope: address audit F11 by defining and enforcing ownership for `web`, `hmi`, `ui`, `control`, and `runtime_cloud`.
 
@@ -138,6 +138,11 @@ Phase 4 adapter-port evidence captured on 2026-04-30:
 - `crates/trust-runtime/src/web/ui_routes.rs` `/hmi/export.json` and `crates/trust-runtime/src/web/runtime_cloud_state/config.rs` config-agent apply flow now use the approved web dispatch helper.
 - `xtask/src/full_map.rs` records `direct web control-dispatch bypass findings: 0` and has a known-bad CHECK-07 fixture for direct web `handle_request_value` dispatch.
 - Validation: `RUSTUP_TOOLCHAIN=1.95 cargo run -p xtask -- architecture-doctor --full-map`, `RUSTUP_TOOLCHAIN=1.95 cargo test -p xtask direct_control_dispatch -- --nocapture`, `RUSTUP_TOOLCHAIN=1.95 cargo test -p trust-runtime --test web_io_config_integration runtime_cloud_config_agent -- --nocapture`, and `RUSTUP_TOOLCHAIN=1.95 cargo test -p trust-runtime --test hmi_readonly_integration hmi_standalone_export -- --nocapture` pass.
+
+Phase 4 runtime-cloud extraction evidence captured on 2026-04-30:
+
+- `crates/trust-runtime/src/web/runtime_cloud_policy.rs` moved to `crates/trust-runtime/src/runtime_cloud/profile_policy.rs`; web now imports the profile/TLS/WAN allowlist policy as a runtime-cloud domain contract instead of owning it.
+- `crates/trust-runtime/tests/runtime_cloud_architecture.rs` includes `runtime_cloud/profile_policy.rs` in the runtime-cloud no-transport-import assertion.
 
 ## Phase 5 - Tests
 


### PR DESCRIPTION
## Summary
- Move runtime-cloud profile/TLS/WAN allowlist policy from `web` into `runtime_cloud/profile_policy.rs`.
- Keep web as the transport adapter by importing the runtime-cloud policy contract.
- Extend the runtime-cloud architecture test so the moved policy cannot import web/transport modules.
- Record `RTHOST-P4-004` extraction evidence in the host-surface checklist.

## Validation
- `RUSTUP_TOOLCHAIN=1.95 just fmt`
- `RUSTUP_TOOLCHAIN=1.95 cargo test -p trust-runtime --lib runtime_cloud::profile_policy -- --nocapture`
- `RUSTUP_TOOLCHAIN=1.95 cargo test -p trust-runtime --test runtime_cloud_architecture -- --nocapture`
- `RUSTUP_TOOLCHAIN=1.95 cargo test -p trust-runtime --test web_io_config_integration runtime_cloud_preflight -- --nocapture`
- `RUSTUP_TOOLCHAIN=1.95 cargo run -p xtask -- architecture-doctor --full-map`
- `RUSTUP_TOOLCHAIN=1.95 cargo clippy -p trust-runtime --all-targets -- -D warnings`
- Pre-commit hook with `RUSTUP_TOOLCHAIN=1.95`: `fmt` and workspace `clippy`
