### PR TITLE
chore(architecture): move runtime cloud link policy

### DIFF
--- a/crates/trust-runtime/src/runtime_cloud/link_policy.rs
+++ b/crates/trust-runtime/src/runtime_cloud/link_policy.rs
@@ -1,0 +1,290 @@
+//! Runtime-cloud link transport preference and topology projection policy.
+
+#![allow(missing_docs)]
+
+use std::collections::{BTreeMap, HashSet};
+use std::net::IpAddr;
+
+use serde::{Deserialize, Serialize};
+
+use crate::config::{
+    RuntimeCloudLinkPreferenceRule, RuntimeCloudPreferredTransport, RuntimeCloudProfile,
+};
+use crate::runtime_cloud::contracts::ReasonCode;
+use crate::runtime_cloud::projection::{ChannelType, FleetNode, RuntimeCloudUiState};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum RuntimeCloudLinkTransport {
+    Realtime,
+    Zenoh,
+    Mesh,
+    Mqtt,
+    #[serde(rename = "modbus-tcp")]
+    ModbusTcp,
+    #[serde(rename = "opcua")]
+    OpcUa,
+    Discovery,
+    Web,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct RuntimeCloudLinkTransportPreference {
+    pub(crate) source: String,
+    pub(crate) target: String,
+    pub(crate) transport: RuntimeCloudLinkTransport,
+    pub(crate) actor: String,
+    pub(crate) updated_at_ns: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub(crate) struct RuntimeCloudLinkTransportState {
+    pub(crate) links: BTreeMap<String, RuntimeCloudLinkTransportPreference>,
+}
+
+pub(crate) fn runtime_cloud_link_transport_for(
+    state: &RuntimeCloudLinkTransportState,
+    source: &str,
+    target: &str,
+) -> Option<RuntimeCloudLinkTransport> {
+    let key = runtime_cloud_link_key(source, target)?;
+    state.links.get(key.as_str()).map(|entry| entry.transport)
+}
+
+pub(crate) fn runtime_cloud_set_link_transport(
+    state: &mut RuntimeCloudLinkTransportState,
+    source: &str,
+    target: &str,
+    transport: RuntimeCloudLinkTransport,
+    actor: &str,
+    updated_at_ns: u64,
+) -> Result<RuntimeCloudLinkTransportPreference, ReasonCode> {
+    if actor.trim().is_empty() {
+        return Err(ReasonCode::ContractViolation);
+    }
+    let Some(key) = runtime_cloud_link_key(source, target) else {
+        return Err(ReasonCode::ContractViolation);
+    };
+    let preference = RuntimeCloudLinkTransportPreference {
+        source: source.trim().to_string(),
+        target: target.trim().to_string(),
+        transport,
+        actor: actor.trim().to_string(),
+        updated_at_ns,
+    };
+    state.links.insert(key, preference.clone());
+    Ok(preference)
+}
+
+pub(crate) fn runtime_cloud_seed_link_transport_preferences(
+    state: &mut RuntimeCloudLinkTransportState,
+    preferences: &[RuntimeCloudLinkPreferenceRule],
+    actor: &str,
+    updated_at_ns: u64,
+) -> bool {
+    let actor = actor.trim();
+    if actor.is_empty() {
+        return false;
+    }
+    let mut changed = false;
+    let mut configured_keys = HashSet::<String>::new();
+
+    for rule in preferences {
+        let Some(key) = runtime_cloud_link_key(rule.source.as_str(), rule.target.as_str()) else {
+            continue;
+        };
+        configured_keys.insert(key.clone());
+        let transport = runtime_cloud_config_transport(rule.transport);
+        let source = rule.source.trim().to_string();
+        let target = rule.target.trim().to_string();
+
+        let should_update = match state.links.get(key.as_str()) {
+            Some(existing) => {
+                existing.source != source
+                    || existing.target != target
+                    || existing.transport != transport
+                    || existing.actor != actor
+            }
+            None => true,
+        };
+        if !should_update {
+            continue;
+        }
+        state.links.insert(
+            key,
+            RuntimeCloudLinkTransportPreference {
+                source,
+                target,
+                transport,
+                actor: actor.to_string(),
+                updated_at_ns,
+            },
+        );
+        changed = true;
+    }
+
+    let stale_keys = state
+        .links
+        .iter()
+        .filter_map(|(key, value)| {
+            if value.actor == actor && !configured_keys.contains(key) {
+                Some(key.clone())
+            } else {
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+    for key in stale_keys {
+        state.links.remove(key.as_str());
+        changed = true;
+    }
+
+    changed
+}
+
+pub(crate) fn runtime_cloud_apply_link_transport_preferences(
+    ui_state: &mut RuntimeCloudUiState,
+    state: &RuntimeCloudLinkTransportState,
+    same_host: impl Fn(&str, &str) -> bool,
+) {
+    let mut realtime_overlays = Vec::new();
+    for edge in &mut ui_state.topology.edges {
+        let Some(transport) =
+            runtime_cloud_link_transport_for(state, edge.source.as_str(), edge.target.as_str())
+        else {
+            continue;
+        };
+
+        if transport == RuntimeCloudLinkTransport::Realtime {
+            if !same_host(edge.source.as_str(), edge.target.as_str()) {
+                continue;
+            }
+            let mut realtime = edge.clone();
+            realtime.channel_type = ChannelType::T0HardRt;
+            // Mesh packet-loss metrics are not meaningful for local SHM realtime lanes.
+            realtime.loss_pct = None;
+            realtime.latency_ms_p95 = None;
+            realtime_overlays.push(realtime);
+            continue;
+        }
+
+        edge.channel_type = runtime_cloud_link_channel_type(transport);
+        if edge.channel_type != ChannelType::MeshT2Ops {
+            edge.loss_pct = None;
+            edge.latency_ms_p95 = None;
+        }
+    }
+    ui_state.topology.edges.extend(realtime_overlays);
+}
+
+pub(crate) fn runtime_cloud_compute_host_groups(
+    nodes: &[FleetNode],
+    same_host: impl Fn(&str, &str) -> bool,
+) -> Vec<Vec<String>> {
+    if nodes.is_empty() {
+        return Vec::new();
+    }
+    let mut ids: Vec<&str> = nodes.iter().map(|n| n.runtime_id.as_str()).collect();
+    ids.sort();
+
+    if ids.len() == 1 {
+        return vec![vec![ids[0].to_string()]];
+    }
+
+    let mut parent: Vec<usize> = (0..ids.len()).collect();
+    fn find(parent: &mut [usize], mut i: usize) -> usize {
+        while parent[i] != i {
+            parent[i] = parent[parent[i]];
+            i = parent[i];
+        }
+        i
+    }
+    for i in 0..ids.len() {
+        for j in (i + 1)..ids.len() {
+            if same_host(ids[i], ids[j]) {
+                let ri = find(&mut parent, i);
+                let rj = find(&mut parent, j);
+                if ri != rj {
+                    parent[ri] = rj;
+                }
+            }
+        }
+    }
+    let mut groups_map = BTreeMap::<usize, Vec<String>>::new();
+    for (i, id) in ids.iter().enumerate() {
+        let root = find(&mut parent, i);
+        groups_map.entry(root).or_default().push((*id).to_string());
+    }
+    let mut groups: Vec<Vec<String>> = groups_map.into_values().collect();
+    for group in &mut groups {
+        group.sort();
+    }
+    groups.sort_by(|a, b| a[0].cmp(&b[0]));
+    groups
+}
+
+pub(crate) fn runtime_cloud_topology_feature_flags(
+    profile: RuntimeCloudProfile,
+) -> BTreeMap<String, bool> {
+    let mut flags = BTreeMap::new();
+    match profile {
+        RuntimeCloudProfile::Dev => {
+            flags.insert("host_containers".to_string(), true);
+            flags.insert("device_discovery".to_string(), true);
+            flags.insert("edit_mode".to_string(), true);
+            flags.insert("module_slots".to_string(), true);
+        }
+        RuntimeCloudProfile::Plant | RuntimeCloudProfile::Wan => {
+            flags.insert("host_containers".to_string(), true);
+        }
+    }
+    flags
+}
+
+pub(crate) fn runtime_cloud_addresses_share_host(source: &[IpAddr], target: &[IpAddr]) -> bool {
+    if target.iter().any(IpAddr::is_loopback) {
+        return true;
+    }
+    if source.is_empty() || target.is_empty() {
+        return false;
+    }
+    let source_set = source.iter().copied().collect::<HashSet<_>>();
+    target.iter().any(|address| source_set.contains(address))
+}
+
+fn runtime_cloud_link_key(source: &str, target: &str) -> Option<String> {
+    let source = source.trim();
+    let target = target.trim();
+    if source.is_empty() || target.is_empty() {
+        return None;
+    }
+    Some(format!("{source}->{target}"))
+}
+
+fn runtime_cloud_config_transport(
+    transport: RuntimeCloudPreferredTransport,
+) -> RuntimeCloudLinkTransport {
+    match transport {
+        RuntimeCloudPreferredTransport::Realtime => RuntimeCloudLinkTransport::Realtime,
+        RuntimeCloudPreferredTransport::Zenoh => RuntimeCloudLinkTransport::Zenoh,
+        RuntimeCloudPreferredTransport::Mesh => RuntimeCloudLinkTransport::Mesh,
+        RuntimeCloudPreferredTransport::Mqtt => RuntimeCloudLinkTransport::Mqtt,
+        RuntimeCloudPreferredTransport::ModbusTcp => RuntimeCloudLinkTransport::ModbusTcp,
+        RuntimeCloudPreferredTransport::OpcUa => RuntimeCloudLinkTransport::OpcUa,
+        RuntimeCloudPreferredTransport::Discovery => RuntimeCloudLinkTransport::Discovery,
+        RuntimeCloudPreferredTransport::Web => RuntimeCloudLinkTransport::Web,
+    }
+}
+
+fn runtime_cloud_link_channel_type(transport: RuntimeCloudLinkTransport) -> ChannelType {
+    match transport {
+        RuntimeCloudLinkTransport::Realtime => ChannelType::T0HardRt,
+        RuntimeCloudLinkTransport::Zenoh => ChannelType::MeshT2Ops,
+        RuntimeCloudLinkTransport::Mesh => ChannelType::MeshT1Fast,
+        RuntimeCloudLinkTransport::Discovery => ChannelType::MeshT3Diag,
+        RuntimeCloudLinkTransport::Mqtt
+        | RuntimeCloudLinkTransport::ModbusTcp
+        | RuntimeCloudLinkTransport::OpcUa
+        | RuntimeCloudLinkTransport::Web => ChannelType::FederationBridge,
+    }
+}

--- a/crates/trust-runtime/src/runtime_cloud/mod.rs
+++ b/crates/trust-runtime/src/runtime_cloud/mod.rs
@@ -15,6 +15,7 @@
 pub mod contracts;
 pub mod ha;
 pub mod keyspace;
+pub(crate) mod link_policy;
 pub(crate) mod profile_policy;
 pub mod projection;
 pub mod routing;

--- a/crates/trust-runtime/src/web.rs
+++ b/crates/trust-runtime/src/web.rs
@@ -39,6 +39,9 @@ use crate::runtime_cloud::ha::{
     RuntimeCloudHaDispatchGate, RuntimeCloudHaDispatchRecord, RuntimeCloudHaDispatchTicket,
     RuntimeCloudHaRequest,
 };
+use crate::runtime_cloud::link_policy::{
+    RuntimeCloudLinkTransport, RuntimeCloudLinkTransportPreference, RuntimeCloudLinkTransportState,
+};
 use crate::runtime_cloud::profile_policy::{
     runtime_cloud_apply_profile_policy, runtime_cloud_profile_precondition,
 };

--- a/crates/trust-runtime/src/web/models.rs
+++ b/crates/trust-runtime/src/web/models.rs
@@ -7,6 +7,9 @@ use std::collections::BTreeMap;
 use serde::{Deserialize, Serialize};
 
 use crate::runtime_cloud::contracts::{ConfigMeta, ConfigStatus, ReasonCode};
+use crate::runtime_cloud::link_policy::{
+    RuntimeCloudLinkTransport, RuntimeCloudLinkTransportPreference,
+};
 use crate::runtime_cloud::routing::RuntimeCloudActionPreflight;
 
 #[derive(Debug, Deserialize)]
@@ -115,21 +118,6 @@ pub(super) struct RuntimeCloudDesiredWriteRequest {
     pub(super) expected_etag: Option<String>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub(super) enum RuntimeCloudLinkTransport {
-    Realtime,
-    Zenoh,
-    Mesh,
-    Mqtt,
-    #[serde(rename = "modbus-tcp")]
-    ModbusTcp,
-    #[serde(rename = "opcua")]
-    OpcUa,
-    Discovery,
-    Web,
-}
-
 #[derive(Debug, Deserialize)]
 pub(super) struct RuntimeCloudLinkTransportSetRequest {
     pub(super) api_version: String,
@@ -137,20 +125,6 @@ pub(super) struct RuntimeCloudLinkTransportSetRequest {
     pub(super) source: String,
     pub(super) target: String,
     pub(super) transport: RuntimeCloudLinkTransport,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub(super) struct RuntimeCloudLinkTransportPreference {
-    pub(super) source: String,
-    pub(super) target: String,
-    pub(super) transport: RuntimeCloudLinkTransport,
-    pub(super) actor: String,
-    pub(super) updated_at_ns: u64,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, Default)]
-pub(super) struct RuntimeCloudLinkTransportState {
-    pub(super) links: BTreeMap<String, RuntimeCloudLinkTransportPreference>,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/crates/trust-runtime/src/web/runtime_cloud_state/links.rs
+++ b/crates/trust-runtime/src/web/runtime_cloud_state/links.rs
@@ -1,9 +1,10 @@
-use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::collections::{BTreeMap, BTreeSet};
 use std::net::IpAddr;
 use std::path::{Path, PathBuf};
 
 use super::*;
-use crate::runtime_cloud::projection::{ChannelType, RuntimeCloudUiState};
+use crate::runtime_cloud::link_policy;
+use crate::runtime_cloud::projection::RuntimeCloudUiState;
 
 pub(in crate::web) fn runtime_cloud_links_state_path(
     bundle_root: Option<&PathBuf>,
@@ -43,14 +44,14 @@ pub(in crate::web) fn runtime_cloud_links_store_state(
     }
 }
 
+#[cfg(test)]
 pub(in crate::web) fn runtime_cloud_link_transport_for(
     state: &Mutex<RuntimeCloudLinkTransportState>,
     source: &str,
     target: &str,
 ) -> Option<RuntimeCloudLinkTransport> {
-    let key = runtime_cloud_link_key(source, target)?;
     let guard = state.lock().ok()?;
-    guard.links.get(key.as_str()).map(|entry| entry.transport)
+    link_policy::runtime_cloud_link_transport_for(&guard, source, target)
 }
 
 pub(in crate::web) fn runtime_cloud_link_set_transport(
@@ -61,21 +62,15 @@ pub(in crate::web) fn runtime_cloud_link_set_transport(
     actor: &str,
     persist_path: Option<&Path>,
 ) -> Result<RuntimeCloudLinkTransportPreference, ReasonCode> {
-    if actor.trim().is_empty() {
-        return Err(ReasonCode::ContractViolation);
-    }
-    let Some(key) = runtime_cloud_link_key(source, target) else {
-        return Err(ReasonCode::ContractViolation);
-    };
     let mut guard = state.lock().map_err(|_| ReasonCode::TransportFailure)?;
-    let preference = RuntimeCloudLinkTransportPreference {
-        source: source.trim().to_string(),
-        target: target.trim().to_string(),
+    let preference = link_policy::runtime_cloud_set_link_transport(
+        &mut guard,
+        source,
+        target,
         transport,
-        actor: actor.trim().to_string(),
-        updated_at_ns: now_ns(),
-    };
-    guard.links.insert(key, preference.clone());
+        actor,
+        now_ns(),
+    )?;
     runtime_cloud_links_store_state(persist_path, &guard);
     Ok(preference)
 }
@@ -85,65 +80,7 @@ pub(in crate::web) fn runtime_cloud_seed_link_transport_preferences(
     preferences: &[crate::config::RuntimeCloudLinkPreferenceRule],
     actor: &str,
 ) -> bool {
-    let actor = actor.trim();
-    if actor.is_empty() {
-        return false;
-    }
-    let mut changed = false;
-    let mut configured_keys = HashSet::<String>::new();
-    let updated_at_ns = now_ns();
-
-    for rule in preferences {
-        let Some(key) = runtime_cloud_link_key(rule.source.as_str(), rule.target.as_str()) else {
-            continue;
-        };
-        configured_keys.insert(key.clone());
-        let transport = runtime_cloud_config_transport(rule.transport);
-        let source = rule.source.trim().to_string();
-        let target = rule.target.trim().to_string();
-
-        let should_update = match state.links.get(key.as_str()) {
-            Some(existing) => {
-                existing.source != source
-                    || existing.target != target
-                    || existing.transport != transport
-                    || existing.actor != actor
-            }
-            None => true,
-        };
-        if !should_update {
-            continue;
-        }
-        state.links.insert(
-            key,
-            RuntimeCloudLinkTransportPreference {
-                source,
-                target,
-                transport,
-                actor: actor.to_string(),
-                updated_at_ns,
-            },
-        );
-        changed = true;
-    }
-
-    let stale_keys = state
-        .links
-        .iter()
-        .filter_map(|(key, value)| {
-            if value.actor == actor && !configured_keys.contains(key) {
-                Some(key.clone())
-            } else {
-                None
-            }
-        })
-        .collect::<Vec<_>>();
-    for key in stale_keys {
-        state.links.remove(key.as_str());
-        changed = true;
-    }
-
-    changed
+    link_policy::runtime_cloud_seed_link_transport_preferences(state, preferences, actor, now_ns())
 }
 
 pub(in crate::web) fn runtime_cloud_apply_link_transport_preferences(
@@ -151,40 +88,20 @@ pub(in crate::web) fn runtime_cloud_apply_link_transport_preferences(
     state: &Mutex<RuntimeCloudLinkTransportState>,
     discovery: Option<&DiscoveryState>,
 ) {
-    let mut realtime_overlays = Vec::new();
-    for edge in &mut ui_state.topology.edges {
-        let Some(transport) =
-            runtime_cloud_link_transport_for(state, edge.source.as_str(), edge.target.as_str())
-        else {
-            continue;
-        };
-
-        if transport == RuntimeCloudLinkTransport::Realtime {
-            if let Some(discovery_state) = discovery {
-                if !runtime_cloud_link_is_same_host(
-                    discovery_state,
-                    edge.source.as_str(),
-                    edge.target.as_str(),
-                ) {
-                    continue;
-                }
-            }
-            let mut realtime = edge.clone();
-            realtime.channel_type = ChannelType::T0HardRt;
-            // Mesh packet-loss metrics are not meaningful for local SHM realtime lanes.
-            realtime.loss_pct = None;
-            realtime.latency_ms_p95 = None;
-            realtime_overlays.push(realtime);
-            continue;
-        }
-
-        edge.channel_type = runtime_cloud_link_channel_type(transport);
-        if edge.channel_type != ChannelType::MeshT2Ops {
-            edge.loss_pct = None;
-            edge.latency_ms_p95 = None;
-        }
-    }
-    ui_state.topology.edges.extend(realtime_overlays);
+    let Ok(guard) = state.lock() else {
+        return;
+    };
+    link_policy::runtime_cloud_apply_link_transport_preferences(
+        ui_state,
+        &guard,
+        |source, target| {
+            discovery
+                .map(|discovery_state| {
+                    runtime_cloud_link_is_same_host(discovery_state, source, target)
+                })
+                .unwrap_or(true)
+        },
+    );
 }
 
 pub(in crate::web) fn runtime_cloud_link_is_same_host(
@@ -215,7 +132,10 @@ pub(in crate::web) fn runtime_cloud_link_is_same_host(
         .get(target)
         .cloned()
         .unwrap_or_default();
-    runtime_cloud_addresses_share_host(source_addresses.as_slice(), target_addresses.as_slice())
+    link_policy::runtime_cloud_addresses_share_host(
+        source_addresses.as_slice(),
+        target_addresses.as_slice(),
+    )
 }
 
 pub(in crate::web) fn runtime_cloud_compute_host_groups(
@@ -225,78 +145,24 @@ pub(in crate::web) fn runtime_cloud_compute_host_groups(
     if nodes.is_empty() {
         return Vec::new();
     }
-    let mut ids: Vec<&str> = nodes.iter().map(|n| n.runtime_id.as_str()).collect();
-    ids.sort();
-
     let Some(discovery) = discovery else {
-        return ids.into_iter().map(|id| vec![id.to_string()]).collect();
+        let mut groups = nodes
+            .iter()
+            .map(|node| vec![node.runtime_id.clone()])
+            .collect::<Vec<_>>();
+        groups.sort_by(|a, b| a[0].cmp(&b[0]));
+        return groups;
     };
 
-    if ids.len() == 1 {
-        return vec![vec![ids[0].to_string()]];
-    }
-
-    // Union-Find
-    let mut parent: Vec<usize> = (0..ids.len()).collect();
-    fn find(parent: &mut [usize], mut i: usize) -> usize {
-        while parent[i] != i {
-            parent[i] = parent[parent[i]];
-            i = parent[i];
-        }
-        i
-    }
-    for i in 0..ids.len() {
-        for j in (i + 1)..ids.len() {
-            if runtime_cloud_link_is_same_host(discovery, ids[i], ids[j]) {
-                let ri = find(&mut parent, i);
-                let rj = find(&mut parent, j);
-                if ri != rj {
-                    parent[ri] = rj;
-                }
-            }
-        }
-    }
-    // Collect groups
-    let mut groups_map = BTreeMap::<usize, Vec<String>>::new();
-    for (i, id) in ids.iter().enumerate() {
-        let root = find(&mut parent, i);
-        groups_map.entry(root).or_default().push((*id).to_string());
-    }
-    // Include singleton groups and sort deterministically
-    let mut groups: Vec<Vec<String>> = groups_map.into_values().collect();
-    for group in &mut groups {
-        group.sort();
-    }
-    groups.sort_by(|a, b| a[0].cmp(&b[0]));
-    groups
+    link_policy::runtime_cloud_compute_host_groups(nodes, |source, target| {
+        runtime_cloud_link_is_same_host(discovery, source, target)
+    })
 }
 
 pub(in crate::web) fn runtime_cloud_topology_feature_flags(
     profile: crate::config::RuntimeCloudProfile,
 ) -> BTreeMap<String, bool> {
-    use crate::config::RuntimeCloudProfile;
-    let mut flags = BTreeMap::new();
-    match profile {
-        RuntimeCloudProfile::Dev => {
-            flags.insert("host_containers".to_string(), true);
-            flags.insert("device_discovery".to_string(), true);
-            flags.insert("edit_mode".to_string(), true);
-            flags.insert("module_slots".to_string(), true);
-        }
-        RuntimeCloudProfile::Plant | RuntimeCloudProfile::Wan => {
-            flags.insert("host_containers".to_string(), true);
-        }
-    }
-    flags
-}
-
-fn runtime_cloud_link_key(source: &str, target: &str) -> Option<String> {
-    let source = source.trim();
-    let target = target.trim();
-    if source.is_empty() || target.is_empty() {
-        return None;
-    }
-    Some(format!("{source}->{target}"))
+    link_policy::runtime_cloud_topology_feature_flags(profile)
 }
 
 fn runtime_cloud_discovery_addresses_by_runtime(
@@ -351,51 +217,6 @@ fn runtime_cloud_host_group_match(
             .iter()
             .any(|group| target_groups.contains(group)),
     )
-}
-
-fn runtime_cloud_config_transport(
-    transport: crate::config::RuntimeCloudPreferredTransport,
-) -> RuntimeCloudLinkTransport {
-    match transport {
-        crate::config::RuntimeCloudPreferredTransport::Realtime => {
-            RuntimeCloudLinkTransport::Realtime
-        }
-        crate::config::RuntimeCloudPreferredTransport::Zenoh => RuntimeCloudLinkTransport::Zenoh,
-        crate::config::RuntimeCloudPreferredTransport::Mesh => RuntimeCloudLinkTransport::Mesh,
-        crate::config::RuntimeCloudPreferredTransport::Mqtt => RuntimeCloudLinkTransport::Mqtt,
-        crate::config::RuntimeCloudPreferredTransport::ModbusTcp => {
-            RuntimeCloudLinkTransport::ModbusTcp
-        }
-        crate::config::RuntimeCloudPreferredTransport::OpcUa => RuntimeCloudLinkTransport::OpcUa,
-        crate::config::RuntimeCloudPreferredTransport::Discovery => {
-            RuntimeCloudLinkTransport::Discovery
-        }
-        crate::config::RuntimeCloudPreferredTransport::Web => RuntimeCloudLinkTransport::Web,
-    }
-}
-
-fn runtime_cloud_link_channel_type(transport: RuntimeCloudLinkTransport) -> ChannelType {
-    match transport {
-        RuntimeCloudLinkTransport::Realtime => ChannelType::T0HardRt,
-        RuntimeCloudLinkTransport::Zenoh => ChannelType::MeshT2Ops,
-        RuntimeCloudLinkTransport::Mesh => ChannelType::MeshT1Fast,
-        RuntimeCloudLinkTransport::Discovery => ChannelType::MeshT3Diag,
-        RuntimeCloudLinkTransport::Mqtt
-        | RuntimeCloudLinkTransport::ModbusTcp
-        | RuntimeCloudLinkTransport::OpcUa
-        | RuntimeCloudLinkTransport::Web => ChannelType::FederationBridge,
-    }
-}
-
-fn runtime_cloud_addresses_share_host(source: &[IpAddr], target: &[IpAddr]) -> bool {
-    if target.iter().any(IpAddr::is_loopback) {
-        return true;
-    }
-    if source.is_empty() || target.is_empty() {
-        return false;
-    }
-    let source_set = source.iter().copied().collect::<HashSet<_>>();
-    target.iter().any(|address| source_set.contains(address))
 }
 
 #[cfg(test)]

--- a/crates/trust-runtime/tests/runtime_cloud_architecture.rs
+++ b/crates/trust-runtime/tests/runtime_cloud_architecture.rs
@@ -11,6 +11,7 @@ fn runtime_cloud_core_modules_do_not_import_transport_layers() {
     let sources = [
         "src/runtime_cloud/contracts.rs",
         "src/runtime_cloud/ha.rs",
+        "src/runtime_cloud/link_policy.rs",
         "src/runtime_cloud/profile_policy.rs",
         "src/runtime_cloud/projection.rs",
         "src/runtime_cloud/routing.rs",

--- a/docs/internal/testing/checklists/runtime-host-surface-ownership-checklist.md
+++ b/docs/internal/testing/checklists/runtime-host-surface-ownership-checklist.md
@@ -142,7 +142,10 @@ Phase 4 adapter-port evidence captured on 2026-04-30:
 Phase 4 runtime-cloud extraction evidence captured on 2026-04-30:
 
 - `crates/trust-runtime/src/web/runtime_cloud_policy.rs` moved to `crates/trust-runtime/src/runtime_cloud/profile_policy.rs`; web now imports the profile/TLS/WAN allowlist policy as a runtime-cloud domain contract instead of owning it.
+- `crates/trust-runtime/src/runtime_cloud/link_policy.rs` now owns link transport preference state, TOML preference seeding, topology channel projection, feature flags, and host-group grouping policy. `crates/trust-runtime/src/web/runtime_cloud_state/links.rs` remains the web adapter for filesystem persistence, mutex locking, and discovery-backed same-host checks.
 - `crates/trust-runtime/tests/runtime_cloud_architecture.rs` includes `runtime_cloud/profile_policy.rs` in the runtime-cloud no-transport-import assertion.
+- `crates/trust-runtime/tests/runtime_cloud_architecture.rs` includes `runtime_cloud/link_policy.rs` in the runtime-cloud no-transport-import assertion.
+- Validation: `RUSTUP_TOOLCHAIN=1.95 cargo test -p trust-runtime --lib web::runtime_cloud_state::links -- --nocapture`, `RUSTUP_TOOLCHAIN=1.95 cargo test -p trust-runtime --test web_io_config_integration runtime_cloud_link -- --nocapture`, `RUSTUP_TOOLCHAIN=1.95 cargo test -p trust-runtime --test web_ide_integration runtime_cloud -- --nocapture`, `RUSTUP_TOOLCHAIN=1.95 cargo test -p trust-runtime --test runtime_cloud_architecture -- --nocapture`, `RUSTUP_TOOLCHAIN=1.95 cargo run -p xtask -- architecture-doctor --full-map`, and `RUSTUP_TOOLCHAIN=1.95 cargo clippy -p trust-runtime --all-targets -- -D warnings` pass.
 
 ## Phase 5 - Tests
 


### PR DESCRIPTION
## Summary
- Move runtime-cloud link transport preference state and topology projection policy into `runtime_cloud::link_policy`.
- Keep `web/runtime_cloud_state/links.rs` as the adapter for filesystem persistence, mutex locking, and discovery-backed same-host checks.
- Add `link_policy.rs` to the runtime-cloud no-transport-import architecture assertion and record RTHOST-P4-004 evidence.

## Validation
- `RUSTUP_TOOLCHAIN=1.95 cargo test -p trust-runtime --lib web::runtime_cloud_state::links -- --nocapture`
- `RUSTUP_TOOLCHAIN=1.95 cargo test -p trust-runtime --test web_io_config_integration runtime_cloud_link -- --nocapture`
- `RUSTUP_TOOLCHAIN=1.95 cargo test -p trust-runtime --test web_ide_integration runtime_cloud -- --nocapture`
- `RUSTUP_TOOLCHAIN=1.95 cargo test -p trust-runtime --test runtime_cloud_architecture -- --nocapture`
- `RUSTUP_TOOLCHAIN=1.95 cargo run -p xtask -- architecture-doctor --full-map`
- `RUSTUP_TOOLCHAIN=1.95 cargo clippy -p trust-runtime --all-targets -- -D warnings`
- pre-commit hook: `just fmt` + workspace clippy passed