### PR TITLE
Retry MQTT live cycle on transport errors

### DIFF
--- a/crates/trust-runtime/tests/io_multidriver_live.rs
+++ b/crates/trust-runtime/tests/io_multidriver_live.rs
@@ -489,9 +489,9 @@ fn runtime_composes_modbus_and_mqtt_drivers_live() {
                     .last_fault()
                     .map_or_else(|| "<none>".to_string(), ToString::to_string);
                 let retry_text = format!("{text}; last_fault={last_fault}");
-                if !retry_text.contains("i/o freshness")
-                    || !is_retryable_mqtt_live_error(&retry_text)
-                {
+                let is_transient_class = retry_text.contains("i/o freshness")
+                    || retry_text.contains("i/o transport error");
+                if !is_transient_class || !is_retryable_mqtt_live_error(&retry_text) {
                     panic!("execute cycle: {err}; last_fault={last_fault}");
                 }
                 let premature_output = {


### PR DESCRIPTION
Stabilizes `runtime_composes_modbus_and_mqtt_drivers_live` against transient broker disconnects on macOS.

`is_retryable_mqtt_live_error` already covers 'Connection closed by peer abruptly', but the existing guard required the cycle error to also contain 'i/o freshness'. On macOS the disconnect surfaces wrapped as `i/o transport error` instead, so it bypassed the retry and panicked the test (CI failure on PR #79).

Treats both `i/o freshness` and `i/o transport error` as transient classes when the underlying MQTT pattern is in the retryable set.