### PR TITLE
Bump workspace version to 0.24.17

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4597,7 +4597,7 @@ dependencies = [
 
 [[package]]
 name = "trust-debug"
-version = "0.24.15"
+version = "0.24.17"
 dependencies = [
  "glob",
  "indexmap 2.14.0",
@@ -4612,7 +4612,7 @@ dependencies = [
 
 [[package]]
 name = "trust-dev"
-version = "0.24.15"
+version = "0.24.17"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4631,7 +4631,7 @@ dependencies = [
 
 [[package]]
 name = "trust-hir"
-version = "0.24.15"
+version = "0.24.17"
 dependencies = [
  "insta",
  "parking_lot",
@@ -4648,7 +4648,7 @@ dependencies = [
 
 [[package]]
 name = "trust-ide"
-version = "0.24.15"
+version = "0.24.17"
 dependencies = [
  "expect-test",
  "once_cell",
@@ -4661,7 +4661,7 @@ dependencies = [
 
 [[package]]
 name = "trust-lsp"
-version = "0.24.15"
+version = "0.24.17"
 dependencies = [
  "anyhow",
  "expect-test",
@@ -4688,7 +4688,7 @@ dependencies = [
 
 [[package]]
 name = "trust-plcopen"
-version = "0.24.15"
+version = "0.24.17"
 dependencies = [
  "anyhow",
  "crc32fast",
@@ -4701,7 +4701,7 @@ dependencies = [
 
 [[package]]
 name = "trust-runtime"
-version = "0.24.15"
+version = "0.24.17"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -4753,7 +4753,7 @@ dependencies = [
 
 [[package]]
 name = "trust-runtime-core"
-version = "0.24.15"
+version = "0.24.17"
 dependencies = [
  "indexmap 2.14.0",
  "rustc-hash 2.1.2",
@@ -4764,7 +4764,7 @@ dependencies = [
 
 [[package]]
 name = "trust-syntax"
-version = "0.24.15"
+version = "0.24.17"
 dependencies = [
  "drop_bomb",
  "insta",
@@ -4775,7 +4775,7 @@ dependencies = [
 
 [[package]]
 name = "trust-wasm-analysis"
-version = "0.24.15"
+version = "0.24.17"
 dependencies = [
  "rowan",
  "serde",
@@ -5785,7 +5785,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xtask"
-version = "0.24.15"
+version = "0.24.17"
 dependencies = [
  "anyhow",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.24.15"
+version = "0.24.17"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/johannesPettersson80/trust-platform"


### PR DESCRIPTION
Aligns the in-tree version with the next release tag so the trust-lsp binary shipped from `v0.24.17` self-reports its real version. Picks up the PR #81 fixes (call hierarchy FB-instance edges, include_paths scope replacement, first-pass index gate).