### PR TITLE
Sync editors/vscode version to 0.24.17

### DIFF
--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trust-lsp",
-  "version": "0.24.15",
+  "version": "0.24.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trust-lsp",
-      "version": "0.24.15",
+      "version": "0.24.17",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@vscode/codicons": "^0.0.44",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "truST LSP",
   "description": "truST LSP \u2014 IEC 61131-3 Structured Text language support",
   "icon": "icon.png",
-  "version": "0.24.15",
+  "version": "0.24.17",
   "publisher": "trust-platform",
   "license": "MIT OR Apache-2.0",
   "engines": {


### PR DESCRIPTION
Fixes the Version Release Guard failure on main after PR #82 bumped Cargo.toml without touching the VS Code extension package files. The gate cross-checks all three.