### PR TITLE
trust-runtime: fix partial access on function block instance fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 
 ## [Unreleased]
 
-Target release: `v0.24.20`
+Target release: `v0.24.21`
 
 ### Added
 
@@ -118,6 +118,10 @@ Target release: `v0.24.20`
 
 ### Fixed
 
+- Runtime bytecode execution now supports IEC Table 17 partial
+  bit/byte/word/dword access on `BYTE`, `WORD`, `DWORD`, and `LWORD`
+  function-block instance fields, matching the existing program-variable
+  behavior.
 - `architecture-doctor --changed` now follows the current
   `crates/trust-runtime/src/host/...` runtime host layout for initializer and
   evaluation checks.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5640,7 +5640,7 @@ dependencies = [
 
 [[package]]
 name = "trust-debug"
-version = "0.24.20"
+version = "0.24.21"
 dependencies = [
  "glob",
  "indexmap 2.14.0",
@@ -5655,7 +5655,7 @@ dependencies = [
 
 [[package]]
 name = "trust-dev"
-version = "0.24.20"
+version = "0.24.21"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5674,7 +5674,7 @@ dependencies = [
 
 [[package]]
 name = "trust-hir"
-version = "0.24.20"
+version = "0.24.21"
 dependencies = [
  "insta",
  "parking_lot",
@@ -5691,7 +5691,7 @@ dependencies = [
 
 [[package]]
 name = "trust-ide"
-version = "0.24.20"
+version = "0.24.21"
 dependencies = [
  "expect-test",
  "once_cell",
@@ -5704,7 +5704,7 @@ dependencies = [
 
 [[package]]
 name = "trust-lsp"
-version = "0.24.20"
+version = "0.24.21"
 dependencies = [
  "anyhow",
  "expect-test",
@@ -5731,7 +5731,7 @@ dependencies = [
 
 [[package]]
 name = "trust-plcopen"
-version = "0.24.20"
+version = "0.24.21"
 dependencies = [
  "anyhow",
  "crc32fast",
@@ -5744,7 +5744,7 @@ dependencies = [
 
 [[package]]
 name = "trust-runtime"
-version = "0.24.20"
+version = "0.24.21"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5801,7 +5801,7 @@ dependencies = [
 
 [[package]]
 name = "trust-runtime-core"
-version = "0.24.20"
+version = "0.24.21"
 dependencies = [
  "indexmap 2.14.0",
  "rustc-hash 2.1.2",
@@ -5812,7 +5812,7 @@ dependencies = [
 
 [[package]]
 name = "trust-syntax"
-version = "0.24.20"
+version = "0.24.21"
 dependencies = [
  "drop_bomb",
  "insta",
@@ -5823,7 +5823,7 @@ dependencies = [
 
 [[package]]
 name = "trust-twin-compiler"
-version = "0.24.20"
+version = "0.24.21"
 dependencies = [
  "clap",
  "serde",
@@ -5835,7 +5835,7 @@ dependencies = [
 
 [[package]]
 name = "trust-twin-renderer"
-version = "0.24.20"
+version = "0.24.21"
 dependencies = [
  "anyhow",
  "console_error_panic_hook",
@@ -5850,7 +5850,7 @@ dependencies = [
 
 [[package]]
 name = "trust-wasm-analysis"
-version = "0.24.20"
+version = "0.24.21"
 dependencies = [
  "rowan",
  "serde",
@@ -7141,7 +7141,7 @@ checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "xtask"
-version = "0.24.20"
+version = "0.24.21"
 dependencies = [
  "anyhow",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.24.20"
+version = "0.24.21"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/johannesPettersson80/trust-platform"

--- a/crates/trust-hir/tests/snapshots/iec_table_coverage__iec_table_coverage_report.snap
+++ b/crates/trust-hir/tests/snapshots/iec_table_coverage__iec_table_coverage_report.snap
@@ -14,6 +14,10 @@ Table 11 (docs/specs/02-data-types.md)
 Table 12 (docs/specs/02-data-types.md)
   - iec_table12: ok [crates/trust-runtime/tests/types_ref.rs]
 
+Table 17 (docs/specs/02-data-types.md)
+  - table17: ok [crates/trust-runtime/tests/types_bit_access.rs]
+  - table17_fb: ok [crates/trust-runtime/tests/types_bit_access.rs]
+
 Table 13 (docs/specs/03-variables.md)
   - iec_table13: ok [crates/trust-hir/tests/var_sections.rs]
   - multi_name_struct_initializer_values_are_independent: ok [crates/trust-runtime/tests/struct_initializers.rs]

--- a/crates/trust-runtime/src/bytecode/encoder/codegen/dynamic_access.rs
+++ b/crates/trust-runtime/src/bytecode/encoder/codegen/dynamic_access.rs
@@ -59,18 +59,37 @@ impl<'a> BytecodeEncoder<'a> {
         };
 
         let start_len = code.len();
-        let Some(reference) = self.resolve_name_ref(ctx, name)? else {
-            code.truncate(start_len);
-            return Ok(Some(false));
-        };
-        self.emit_load_ref(&reference, code)?;
-        if !self.emit_expr(ctx, value, code)? {
-            code.truncate(start_len);
-            return Ok(Some(false));
+        if let Some(reference) = self.resolve_name_ref(ctx, name)? {
+            self.emit_load_ref(&reference, code)?;
+            if !self.emit_expr(ctx, value, code)? {
+                code.truncate(start_len);
+                return Ok(Some(false));
+            }
+            self.emit_partial_write(partial, code);
+            self.emit_store_ref(&reference, code)?;
+            return Ok(Some(true));
         }
-        self.emit_partial_write(partial, code);
-        self.emit_store_ref(&reference, code)?;
-        Ok(Some(true))
+        if ctx.self_field_name(name).is_some() {
+            if !self.emit_self_field_ref(ctx, name, code)? {
+                code.truncate(start_len);
+                return Ok(Some(false));
+            }
+            code.push(0x32);
+            if !self.emit_expr(ctx, value, code)? {
+                code.truncate(start_len);
+                return Ok(Some(false));
+            }
+            self.emit_partial_write(partial, code);
+            if !self.emit_self_field_ref(ctx, name, code)? {
+                code.truncate(start_len);
+                return Ok(Some(false));
+            }
+            code.push(0x13); // SWAP
+            code.push(0x33); // STORE
+            return Ok(Some(true));
+        }
+        code.truncate(start_len);
+        Ok(Some(false))
     }
 
     fn emit_dynamic_assign(
@@ -262,12 +281,20 @@ impl<'a> BytecodeEncoder<'a> {
         access: crate::value::PartialAccess,
         code: &mut Vec<u8>,
     ) -> Result<bool, BytecodeError> {
-        let Some(reference) = self.resolve_name_ref(ctx, name)? else {
-            return Ok(false);
-        };
-        self.emit_load_ref(&reference, code)?;
-        self.emit_partial_read(access, code);
-        Ok(true)
+        if let Some(reference) = self.resolve_name_ref(ctx, name)? {
+            self.emit_load_ref(&reference, code)?;
+            self.emit_partial_read(access, code);
+            return Ok(true);
+        }
+        if ctx.self_field_name(name).is_some() {
+            if !self.emit_self_field_ref(ctx, name, code)? {
+                return Ok(false);
+            }
+            code.push(0x32);
+            self.emit_partial_read(access, code);
+            return Ok(true);
+        }
+        Ok(false)
     }
 
     fn emit_partial_read(

--- a/crates/trust-runtime/tests/fixtures/complete_program/lib.st
+++ b/crates/trust-runtime/tests/fixtures/complete_program/lib.st
@@ -27,7 +27,15 @@ VAR_INPUT
 END_VAR
 VAR_OUTPUT
     Sum : DINT;
+    StatusByte : BYTE;
+    StatusBit : BOOL;
+END_VAR
+VAR
+    status : WORD := WORD#16#1234;
 END_VAR
 Sum := Sum + In;
+StatusBit := status.%X0;
+StatusByte := status.%B1;
+status.%B0 := BYTE#16#FF;
 END_FUNCTION_BLOCK
 END_NAMESPACE

--- a/crates/trust-runtime/tests/fixtures/complete_program/main.st
+++ b/crates/trust-runtime/tests/fixtures/complete_program/main.st
@@ -9,6 +9,8 @@ VAR
     sensor_size : DINT := 0;
     sensor_type_size : DINT := 0;
     values_size : DINT := 0;
+    acc_status_byte : BYTE;
+    acc_status_bit : BOOL;
     color : Color := Color#Red;
     swap_a : DINT := 10;
     swap_b : DINT := 20;
@@ -35,6 +37,8 @@ values_size := SIZEOF(values);
 sum := DemoLib.Add(A := values[0], B := values[1]);
 acc(In := sum);
 total := acc.Sum;
+acc_status_byte := acc.StatusByte;
+acc_status_bit := acc.StatusBit;
 ok := DemoLib.SwapDint(swap_a, swap_b);
 
 IF ok THEN

--- a/crates/trust-runtime/tests/types_bit_access.rs
+++ b/crates/trust-runtime/tests/types_bit_access.rs
@@ -38,3 +38,74 @@ END_PROGRAM
     assert_eq!(harness.get_output("b"), Some(Value::Byte(0x08)));
     assert_eq!(harness.get_output("w"), Some(Value::Word(0x12FF)));
 }
+
+#[test]
+fn table17_fb() {
+    let source = r#"
+FUNCTION_BLOCK BitAccessFb
+VAR
+    b : BYTE := BYTE#16#00;
+    w : WORD := WORD#16#1234;
+    d : DWORD := DWORD#16#89ABCDEF;
+    l : LWORD := LWORD#16#0123_4567_89AB_CDEF;
+    bit_val : BOOL;
+    byte_val : BYTE;
+    word_val : WORD;
+    dword_val : DWORD;
+END_VAR
+bit_val := b.%X0;
+bit_val := b.7;
+byte_val := w.%B1;
+word_val := d.%W1;
+dword_val := l.%D1;
+b.%X3 := TRUE;
+w.%B0 := BYTE#16#FF;
+END_FUNCTION_BLOCK
+
+PROGRAM Main
+VAR
+    fb : BitAccessFb;
+END_VAR
+fb();
+END_PROGRAM
+"#;
+
+    let mut harness = TestHarness::from_source(source).unwrap();
+    let err = harness.cycle().errors.into_iter().next();
+    assert!(err.is_none(), "expected success, got {err:?}");
+
+    let main_id = match harness.runtime().storage().get_global("Main") {
+        Some(Value::Instance(id)) => *id,
+        other => panic!("expected Main instance, got {other:?}"),
+    };
+    let fb_id = match harness.runtime().storage().get_instance_var(main_id, "fb") {
+        Some(Value::Instance(id)) => *id,
+        other => panic!("expected FB instance, got {other:?}"),
+    };
+    let storage = harness.runtime().storage();
+
+    assert_eq!(
+        storage.get_instance_var(fb_id, "bit_val"),
+        Some(&Value::Bool(false))
+    );
+    assert_eq!(
+        storage.get_instance_var(fb_id, "byte_val"),
+        Some(&Value::Byte(0x12))
+    );
+    assert_eq!(
+        storage.get_instance_var(fb_id, "word_val"),
+        Some(&Value::Word(0x89AB))
+    );
+    assert_eq!(
+        storage.get_instance_var(fb_id, "dword_val"),
+        Some(&Value::DWord(0x0123_4567))
+    );
+    assert_eq!(
+        storage.get_instance_var(fb_id, "b"),
+        Some(&Value::Byte(0x08))
+    );
+    assert_eq!(
+        storage.get_instance_var(fb_id, "w"),
+        Some(&Value::Word(0x12FF))
+    );
+}

--- a/docs/specs/02-data-types.md
+++ b/docs/specs/02-data-types.md
@@ -73,6 +73,44 @@ This specification defines the type system for trust-hir.
 | 20 | `DWORD` | Bit string of 32 | `16#0000_0000` | 32 |
 | 21 | `LWORD` | Bit string of 64 | `16#0000_0000_0000_0000` | 64 |
 
+### Partial Access to ANY_BIT Variables (Table 17, Section 6.6.1.3)
+
+Variables of type `BYTE`, `WORD`, `DWORD`, and `LWORD` support partial
+bit/byte/word/double-word access. The access suffix is appended to the variable
+name with dot notation:
+
+```
+VAR
+  b : BYTE := BYTE#16#00;
+  w : WORD := WORD#16#1234;
+  d : DWORD := DWORD#16#89ABCDEF;
+  l : LWORD := LWORD#16#0123_4567_89AB_CDEF;
+END_VAR
+
+b.%X3 := TRUE;          // write bit 3 of b
+b.7 := FALSE;           // %X may be omitted for bit access
+w.%B0 := BYTE#16#FF;    // write byte 0 of w
+d.%W1;                  // word 1 of d
+l.%D1;                  // double word 1 of l
+```
+
+| Target Type | Bit Access | Byte Access | Word Access | DWord Access |
+|-------------|------------|-------------|-------------|--------------|
+| `BYTE` | `%X0`..`%X7` or `0`..`7` -> `BOOL` | - | - | - |
+| `WORD` | `%X0`..`%X15` or `0`..`15` -> `BOOL` | `%B0`..`%B1` -> `BYTE` | - | - |
+| `DWORD` | `%X0`..`%X31` or `0`..`31` -> `BOOL` | `%B0`..`%B3` -> `BYTE` | `%W0`..`%W1` -> `WORD` | - |
+| `LWORD` | `%X0`..`%X63` or `0`..`63` -> `BOOL` | `%B0`..`%B7` -> `BYTE` | `%W0`..`%W3` -> `WORD` | `%D0`..`%D1` -> `DWORD` |
+
+The lower numbered suffix addresses the lower value part independently of
+target-platform endian layout; bit offset `0` addresses the rightmost bit of
+the value. Partial writes require a value of the selected part type (`BOOL` for
+bit access, `BYTE` for byte access, `WORD` for word access, `DWORD` for dword
+access).
+
+Partial access applies to ordinary variables of the supported `ANY_BIT` types,
+including function block instance fields. It is not valid on directly
+represented variables themselves, for example `%IB10.%X0`.
+
 ## 2. Generic Data Types (Figure 5, Section 6.4.3)
 
 Generic data types are used in standard function/function block specifications. They are identified by the `ANY` prefix.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -132,6 +132,7 @@ Key tables from the IEC 61131-3 standard referenced in these documents:
 | Table 12 | Reference operations | 02-data-types.md |
 | Table 13-14 | Variable declaration | 03-variables.md |
 | Table 15-16 | Arrays, direct variables | 03-variables.md |
+| Table 17 | Partial access to ANY_BIT variables | 02-data-types.md |
 | Table 19 | FUNCTION declaration | 04-pou-declarations.md |
 | Table 22-27 | Type conversion functions | 07-standard-functions.md |
 | Table 28-36 | Standard functions | 07-standard-functions.md |

--- a/docs/specs/coverage/iec-table-test-map.toml
+++ b/docs/specs/coverage/iec-table-test-map.toml
@@ -16,6 +16,11 @@ spec = "docs/specs/02-data-types.md"
 tests = ["iec_table12"]
 
 [[table]]
+id = "Table 17"
+spec = "docs/specs/02-data-types.md"
+tests = ["table17", "table17_fb"]
+
+[[table]]
 id = "Table 13"
 spec = "docs/specs/03-variables.md"
 tests = ["iec_table13", "multi_name_struct_initializer_values_are_independent"]

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trust-lsp",
-  "version": "0.24.20",
+  "version": "0.24.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trust-lsp",
-      "version": "0.24.20",
+      "version": "0.24.21",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@vscode/codicons": "^0.0.44",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "truST LSP",
   "description": "truST LSP \u2014 IEC 61131-3 Structured Text language support",
   "icon": "icon.png",
-  "version": "0.24.20",
+  "version": "0.24.21",
   "publisher": "trust-platform",
   "license": "MIT OR Apache-2.0",
   "engines": {


### PR DESCRIPTION
Hi Johannes, Thank you for creating this wonderful project.

## Summary

- Fix partial bit/byte/word/dword access on FUNCTION_BLOCK instance fields (e.g. `mode.0`, `w.%B1`) that previously failed with an immediate type mismatch at runtime.
- Root cause: dynamic access codegen only resolved targets via global name references, which works in PROGRAM bodies but not for FB-local `VAR` fields.
- Add a self-field fallback for partial reads and writes in `dynamic_access.rs`.
- Add `table17_fb` integration test covering TABLE 17 partial access inside a FUNCTION_BLOCK, parallel to the existing program-level test.

## Problem

Partial access is implemented at the value layer for BYTE/WORD/DWORD/LWORD and works correctly in PROGRAM bodies. In FUNCTION_BLOCK bodies (including nested FB calls from `TEST_FUNCTION_BLOCK`), expressions like `mode.0` on a local BYTE var fail immediately with `TypeMismatch`.

| Context | `mode.0` on BYTE |
|---|---|
| PROGRAM body | Works |
| FUNCTION_BLOCK body | TypeMismatch |
| Nested FB call from TEST_FUNCTION_BLOCK | TypeMismatch |
| `SHR(mode, 0) AND BYTE#1` workaround | Works |

## Solution

When a global name reference is not found, check whether the target is a self-field and emit the appropriate self-field load/store bytecode for partial access:

- **Reads:** load self field → `DUP` → `PARTIAL_READ`
- **Writes:** load self field → `DUP` → evaluate RHS → `PARTIAL_WRITE` → load self field again → `SWAP` → `STORE`

## Test plan

- [x] `cargo test -p trust-runtime table17_fb`
- [x] `cargo test -p trust-runtime table17` (existing program test still passes)
- [x] Verify no regressions in `cargo test -p trust-runtime`