### PR TITLE
Add HIR type-checking for IS_VALID & IS_VALID_BCD

### DIFF
--- a/crates/trust-hir/src/type_check/standard.rs
+++ b/crates/trust-hir/src/type_check/standard.rs
@@ -10,6 +10,7 @@ mod numeric;
 mod selection;
 mod string;
 mod time;
+mod validate;
 
 pub(in crate::type_check) use helpers::is_execution_param;
 
@@ -79,6 +80,8 @@ impl<'a, 'b> StandardChecker<'a, 'b> {
                     self.infer_split_date_time_call(node, &upper)
                 }
                 "DAY_OF_WEEK" => self.infer_day_of_week_call(node),
+                "IS_VALID" => self.infer_is_valid_call(node),
+                "IS_VALID_BCD" => self.infer_is_valid_bcd_call(node),
                 _ => return None,
             };
 

--- a/crates/trust-hir/src/type_check/standard/validate.rs
+++ b/crates/trust-hir/src/type_check/standard/validate.rs
@@ -1,0 +1,62 @@
+use super::super::*;
+use super::helpers::builtin_param;
+
+impl<'a, 'b> StandardChecker<'a, 'b> {
+    pub(in crate::type_check) fn infer_is_valid_call(&mut self, node: &SyntaxNode) -> TypeId {
+        let params = vec![builtin_param("IN", ParamDirection::In)];
+        let call = self.builtin_call(node, params);
+        call.check_formal_arg_count(self, node, 1);
+        if call.arg_count() != 1 {
+            return self
+                .checker
+                .legacy_suppressed_type(DiagnosticCode::WrongArgumentCount, node.text_range());
+        }
+        let Some((arg, arg_type)) = call.arg(0) else {
+            return self
+                .checker
+                .legacy_suppressed_type(DiagnosticCode::WrongArgumentCount, node.text_range());
+        };
+        if arg_type == TypeId::UNKNOWN {
+            return self
+                .checker
+                .legacy_suppressed_type(DiagnosticCode::CannotResolve, arg.range);
+        }
+        if !self.is_real_type(arg_type) {
+            return self.checker.legacy_diagnostic_type(
+                DiagnosticCode::InvalidArgumentType,
+                arg.range,
+                "expected REAL or LREAL type",
+            );
+        }
+        TypeId::BOOL
+    }
+
+    pub(in crate::type_check) fn infer_is_valid_bcd_call(&mut self, node: &SyntaxNode) -> TypeId {
+        let params = vec![builtin_param("IN", ParamDirection::In)];
+        let call = self.builtin_call(node, params);
+        call.check_formal_arg_count(self, node, 1);
+        if call.arg_count() != 1 {
+            return self
+                .checker
+                .legacy_suppressed_type(DiagnosticCode::WrongArgumentCount, node.text_range());
+        }
+        let Some((arg, arg_type)) = call.arg(0) else {
+            return self
+                .checker
+                .legacy_suppressed_type(DiagnosticCode::WrongArgumentCount, node.text_range());
+        };
+        if arg_type == TypeId::UNKNOWN {
+            return self
+                .checker
+                .legacy_suppressed_type(DiagnosticCode::CannotResolve, arg.range);
+        }
+        if !self.is_bit_string_type(arg_type) {
+            return self.checker.legacy_diagnostic_type(
+                DiagnosticCode::InvalidArgumentType,
+                arg.range,
+                "expected bit string type",
+            );
+        }
+        TypeId::BOOL
+    }
+}

--- a/crates/trust-hir/tests/semantic_standard_functions.rs
+++ b/crates/trust-hir/tests/semantic_standard_functions.rs
@@ -128,6 +128,58 @@ END_PROGRAM
 }
 
 #[test]
+// IEC 61131-3 Ed.3 Table 30 (validation functions)
+fn test_standard_validate_functions() {
+    check_no_errors(
+        r#"
+PROGRAM Test
+VAR
+    r: REAL;
+    lr: LREAL;
+    w: WORD;
+    ok: BOOL;
+END_VAR
+ok := IS_VALID(r);
+ok := IS_VALID(lr);
+ok := IS_VALID_BCD(w);
+END_PROGRAM
+"#,
+    );
+}
+
+#[test]
+fn test_is_valid_requires_real() {
+    check_has_error(
+        r#"
+PROGRAM Test
+VAR
+    a: DINT;
+    ok: BOOL;
+END_VAR
+ok := IS_VALID(a);
+END_PROGRAM
+"#,
+        DiagnosticCode::InvalidArgumentType,
+    );
+}
+
+#[test]
+fn test_is_valid_bcd_requires_bit_string() {
+    check_has_error(
+        r#"
+PROGRAM Test
+VAR
+    r: REAL;
+    ok: BOOL;
+END_VAR
+ok := IS_VALID_BCD(r);
+END_PROGRAM
+"#,
+        DiagnosticCode::InvalidArgumentType,
+    );
+}
+
+#[test]
 // IEC 61131-3 Ed.3 Tables 34-36 (string/time functions)
 fn test_standard_string_and_time_functions() {
     check_no_errors(


### PR DESCRIPTION
This pull request adds HIR type-checking for the IEC 61131-3 validation functions `IS_VALID` and `IS_VALID_BCD`.

These functions were already defined in the runtime `stdlib/validate.rs`, but were not accessible to the compiler because they were not wired into the HIR `StandardChecker`.

- Registered `IS_VALID` and `IS_VALID_BCD` in the standard-function dispatcher (`standard.rs`)
- Added `standard/validate.rs` with type inference for both calls:
  - `IS_VALID(IN)` → `BOOL`, requires `REAL` or `LREAL`
  - `IS_VALID_BCD(IN)` → `BOOL`, requires a bit-string type
- Added semantic tests for valid usage and `InvalidArgumentType` errors on wrong operand types