### PR TITLE
Support partial field access on inout struct refs

### DIFF
--- a/crates/trust-runtime/src/bytecode/encoder/codegen/dynamic_access.rs
+++ b/crates/trust-runtime/src/bytecode/encoder/codegen/dynamic_access.rs
@@ -51,45 +51,65 @@ impl<'a> BytecodeEncoder<'a> {
         let crate::program_model::LValue::Field { target, field } = target else {
             return Ok(None);
         };
-        let crate::program_model::LValue::Name(name) = target.as_ref() else {
-            return Ok(None);
-        };
         let Some(partial) = crate::value::parse_partial_access(field.as_str()) else {
             return Ok(None);
         };
 
         let start_len = code.len();
-        if let Some(reference) = self.resolve_name_ref(ctx, name)? {
-            self.emit_load_ref(&reference, code)?;
-            if !self.emit_expr(ctx, value, code)? {
-                code.truncate(start_len);
-                return Ok(Some(false));
+
+        if let crate::program_model::LValue::Name(name) = target.as_ref() {
+            if let Some(reference) = self.resolve_name_ref(ctx, name)? {
+                self.emit_load_ref(&reference, code)?;
+                if !self.emit_expr(ctx, value, code)? {
+                    code.truncate(start_len);
+                    return Ok(Some(false));
+                }
+                self.emit_partial_write(partial, code);
+                self.emit_store_ref(&reference, code)?;
+                return Ok(Some(true));
             }
-            self.emit_partial_write(partial, code);
-            self.emit_store_ref(&reference, code)?;
-            return Ok(Some(true));
+            if ctx.self_field_name(name).is_some() {
+                if !self.emit_self_field_ref(ctx, name, code)? {
+                    code.truncate(start_len);
+                    return Ok(Some(false));
+                }
+                code.push(0x32);
+                if !self.emit_expr(ctx, value, code)? {
+                    code.truncate(start_len);
+                    return Ok(Some(false));
+                }
+                self.emit_partial_write(partial, code);
+                if !self.emit_self_field_ref(ctx, name, code)? {
+                    code.truncate(start_len);
+                    return Ok(Some(false));
+                }
+                code.push(0x13); // SWAP
+                code.push(0x33); // STORE
+                return Ok(Some(true));
+            }
+            code.truncate(start_len);
+            return Ok(Some(false));
         }
-        if ctx.self_field_name(name).is_some() {
-            if !self.emit_self_field_ref(ctx, name, code)? {
-                code.truncate(start_len);
-                return Ok(Some(false));
-            }
-            code.push(0x32);
-            if !self.emit_expr(ctx, value, code)? {
-                code.truncate(start_len);
-                return Ok(Some(false));
-            }
-            self.emit_partial_write(partial, code);
-            if !self.emit_self_field_ref(ctx, name, code)? {
-                code.truncate(start_len);
-                return Ok(Some(false));
-            }
-            code.push(0x13); // SWAP
-            code.push(0x33); // STORE
-            return Ok(Some(true));
+
+        // Non-name target (e.g. s.b.%X3 where s is a struct via VAR_IN_OUT):
+        // get a ref to the base, load+partial-write+store.
+        if !self.emit_dynamic_ref_for_lvalue(ctx, target, code)? {
+            code.truncate(start_len);
+            return Ok(Some(false));
         }
-        code.truncate(start_len);
-        Ok(Some(false))
+        code.push(0x32); // DEREF: load current value at the target ref
+        if !self.emit_expr(ctx, value, code)? {
+            code.truncate(start_len);
+            return Ok(Some(false));
+        }
+        self.emit_partial_write(partial, code);
+        if !self.emit_dynamic_ref_for_lvalue(ctx, target, code)? {
+            code.truncate(start_len);
+            return Ok(Some(false));
+        }
+        code.push(0x13); // SWAP
+        code.push(0x33); // STORE
+        Ok(Some(true))
     }
 
     fn emit_dynamic_assign(

--- a/crates/trust-runtime/src/bytecode/encoder/codegen/expr.rs
+++ b/crates/trust-runtime/src/bytecode/encoder/codegen/expr.rs
@@ -111,6 +111,10 @@ impl<'a> BytecodeEncoder<'a> {
                     }
                 } else if !self.emit_ref_expr(ctx, target, code)? {
                     Ok(false)
+                } else if let Some(access) = crate::value::parse_partial_access(field.as_str()) {
+                    code.push(0x32); // DEREF: load value from the referenced location
+                    self.emit_partial_read(access, code);
+                    Ok(true)
                 } else {
                     let field_idx = self.strings.intern(field.clone());
                     code.push(0x30);

--- a/crates/trust-runtime/tests/types_bit_access.rs
+++ b/crates/trust-runtime/tests/types_bit_access.rs
@@ -2,6 +2,64 @@ use trust_runtime::harness::TestHarness;
 use trust_runtime::value::Value;
 
 #[test]
+fn bit_access_on_struct_byte_via_inout() {
+    // Bit/partial access on a field of a struct passed via VAR_IN_OUT
+    let source = r#"
+TYPE
+    MyStruct : STRUCT
+        b : BYTE;
+        w : WORD;
+    END_STRUCT;
+END_TYPE
+
+FUNCTION_BLOCK BitAccessInoutFb
+VAR_IN_OUT
+    s : MyStruct;
+END_VAR
+VAR_OUTPUT
+    bit_val  : BOOL;
+    byte_val : BYTE;
+END_VAR
+bit_val  := s.b.%X2;
+s.b.%X3  := TRUE;
+byte_val := s.w.%B0;
+s.w.%B1  := BYTE#16#AB;
+END_FUNCTION_BLOCK
+
+PROGRAM Main
+VAR
+    data     : MyStruct;
+    fb       : BitAccessInoutFb;
+    bit_val  : BOOL;
+    byte_val : BYTE;
+    result_b : BYTE;
+    result_w : WORD;
+END_VAR
+data.b := BYTE#16#00;
+data.w := WORD#16#1234;
+fb(s := data);
+bit_val  := fb.bit_val;
+byte_val := fb.byte_val;
+result_b := data.b;
+result_w := data.w;
+END_PROGRAM
+"#;
+
+    let mut harness = TestHarness::from_source(source).unwrap();
+    let err = harness.cycle().errors.into_iter().next();
+    assert!(err.is_none(), "expected success, got {err:?}");
+
+    // s.b.%X2 read from 0x00 before write → false
+    assert_eq!(harness.get_output("bit_val"), Some(Value::Bool(false)));
+    // s.b started as 0x00; bit 3 set → 0x08
+    assert_eq!(harness.get_output("result_b"), Some(Value::Byte(0x08)));
+    // s.w.%B0 read from 0x1234 → 0x34
+    assert_eq!(harness.get_output("byte_val"), Some(Value::Byte(0x34)));
+    // s.w started as 0x1234; high byte (index 1) replaced with 0xAB → 0xAB34
+    assert_eq!(harness.get_output("result_w"), Some(Value::Word(0xAB34)));
+}
+
+#[test]
 fn table17() {
     let source = r#"
 PROGRAM Main


### PR DESCRIPTION
This pull request adds partial bit/byte access on struct fields passed via `VAR_IN_OUT` (e.g. `s.b.%X3 := TRUE` or `bit_val := s.b.%X2`). These failed to compile because dynamic access codegen only handled name-based lvalues (globals and FB self-fields), not nested field access on inout struct references. This extends the work of #88. The norm mention nor inhibits partial bit access from struct members but I fail see why partial bit access should not work on ANY_BIT members of a struct.

## Changes

- Extend partial read/write codegen to resolve non-name lvalues through  `emit_dynamic_ref_for_lvalue`, covering struct field chains such as `s.b.%X3`.
- Add expression codegen for partial reads on referenced struct fields  (deref + partial read).
- Add integration coverage for bit and byte partial access on a struct passed via `VAR_IN_OUT`.

## How it works

**Partial read (`bit_val := s.b.%X2`)**: in field-expression codegen, after `emit_ref_expr` produces a reference, the encoder checks whether the field is a partial-access suffix (`%X`, `%B`, ...). If so, it `DEREF`s the reference to load the value and emits a partial read, instead of treating `%X2` as a normal struct field name.

**Partial write (`s.b.%X3 := TRUE`)**: new chained-lvalue path via `emit_dynamic_ref_for_lvalue`:

1. Resolve a reference to the base field (`s.b`).
2. `DEREF` to load the current value.
3. Apply the partial write with the new value.
4. Re-resolve the reference, `SWAP`, and `STORE` back.

## Testing

- New integration tests in `types_bit_access.rs` covering bit and byte partial access on a `VAR_IN_OUT` struct (read and write).
