### PR TITLE
Harden release evidence wait budgets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           HEAD_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
           python3 ./scripts/check_regression_test_first.py --base "${BASE_SHA}" --head "${HEAD_SHA}"
       - name: Guard release evidence wait budget
-        run: python3 ./scripts/check_version_release_evidence_tests.py
+        run: python3 ./scripts/test_check_version_release_evidence.py
       - run: cargo fmt --all -- --check
       - name: Mark gate success
         if: ${{ success() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,8 @@ jobs:
           BASE_SHA="${{ github.event.pull_request.base.sha || github.event.before }}"
           HEAD_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
           python3 ./scripts/check_regression_test_first.py --base "${BASE_SHA}" --head "${HEAD_SHA}"
+      - name: Guard release evidence wait budget
+        run: python3 ./scripts/check_version_release_evidence_tests.py
       - run: cargo fmt --all -- --check
       - name: Mark gate success
         if: ${{ success() }}
@@ -708,6 +710,7 @@ jobs:
   version-release-guard:
     name: Version Release Guard
     runs-on: ubuntu-latest
+    timeout-minutes: 120
     permissions:
       contents: read
       actions: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on Keep a Changelog and this project adheres to Semantic Ver
 
 ## [Unreleased]
 
-Target release: `v0.24.30`
+Target release: `v0.24.31`
 
 ### Added
 
@@ -320,6 +320,10 @@ Target release: `v0.24.30`
 
 ### Fixed
 
+- ci: the main-branch version release guard now allows 90 minutes for a matching
+  Release workflow to finish, with a larger job budget and a focused regression
+  test, so healthy cold Windows artifact builds do not fail release evidence at
+  the former 30-minute boundary.
 - vscode: fixed stale Devices & Connections refresh and discovery sessions so
   editor-group resize/remounts cannot publish torn capability state or leave old
   Discover cards actionable; hidden webviews now pause polling and resynchronize

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5156,7 +5156,7 @@ dependencies = [
 
 [[package]]
 name = "trust-ads-core"
-version = "0.24.30"
+version = "0.24.31"
 dependencies = [
  "serde",
  "serde_json",
@@ -5165,14 +5165,14 @@ dependencies = [
 
 [[package]]
 name = "trust-ads-server"
-version = "0.24.30"
+version = "0.24.31"
 dependencies = [
  "trust-ads-core",
 ]
 
 [[package]]
 name = "trust-debug"
-version = "0.24.30"
+version = "0.24.31"
 dependencies = [
  "glob",
  "indexmap 2.14.0",
@@ -5187,7 +5187,7 @@ dependencies = [
 
 [[package]]
 name = "trust-dev"
-version = "0.24.30"
+version = "0.24.31"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -5206,7 +5206,7 @@ dependencies = [
 
 [[package]]
 name = "trust-hir"
-version = "0.24.30"
+version = "0.24.31"
 dependencies = [
  "boxcar",
  "insta",
@@ -5224,7 +5224,7 @@ dependencies = [
 
 [[package]]
 name = "trust-ide"
-version = "0.24.30"
+version = "0.24.31"
 dependencies = [
  "expect-test",
  "once_cell",
@@ -5237,7 +5237,7 @@ dependencies = [
 
 [[package]]
 name = "trust-lsp"
-version = "0.24.30"
+version = "0.24.31"
 dependencies = [
  "anyhow",
  "expect-test",
@@ -5264,7 +5264,7 @@ dependencies = [
 
 [[package]]
 name = "trust-plcopen"
-version = "0.24.30"
+version = "0.24.31"
 dependencies = [
  "anyhow",
  "crc32fast",
@@ -5277,7 +5277,7 @@ dependencies = [
 
 [[package]]
 name = "trust-runtime"
-version = "0.24.30"
+version = "0.24.31"
 dependencies = [
  "ads",
  "anyhow",
@@ -5343,7 +5343,7 @@ dependencies = [
 
 [[package]]
 name = "trust-runtime-core"
-version = "0.24.30"
+version = "0.24.31"
 dependencies = [
  "indexmap 2.14.0",
  "rustc-hash 2.1.2",
@@ -5354,7 +5354,7 @@ dependencies = [
 
 [[package]]
 name = "trust-syntax"
-version = "0.24.30"
+version = "0.24.31"
 dependencies = [
  "drop_bomb",
  "insta",
@@ -5365,7 +5365,7 @@ dependencies = [
 
 [[package]]
 name = "trust-wasm-analysis"
-version = "0.24.30"
+version = "0.24.31"
 dependencies = [
  "rowan",
  "serde",
@@ -6385,7 +6385,7 @@ checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "xtask"
-version = "0.24.30"
+version = "0.24.31"
 dependencies = [
  "anyhow",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.24.30"
+version = "0.24.31"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/johannesPettersson80/trust-platform"

--- a/editors/vscode/package-lock.json
+++ b/editors/vscode/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trust-lsp",
-  "version": "0.24.30",
+  "version": "0.24.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trust-lsp",
-      "version": "0.24.30",
+      "version": "0.24.31",
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@vscode/codicons": "^0.0.44",

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "truST",
   "description": "truST — IEC 61131-3 Structured Text language support",
   "icon": "icon.png",
-  "version": "0.24.30",
+  "version": "0.24.31",
   "publisher": "trust-platform",
   "license": "MIT OR Apache-2.0",
   "engines": {

--- a/scripts/check_version_release_evidence.py
+++ b/scripts/check_version_release_evidence.py
@@ -16,6 +16,8 @@ import urllib.request
 from pathlib import Path
 
 NULL_SHA = "0" * 40
+DEFAULT_RUN_DISCOVERY_TIMEOUT_SECONDS = 3 * 60
+DEFAULT_RUN_COMPLETION_TIMEOUT_SECONDS = 90 * 60
 
 
 def run_git(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
@@ -87,7 +89,7 @@ def fail(message: str) -> int:
     return 1
 
 
-def main() -> int:
+def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description=(
             "Fail CI when a workspace version bump on main/master is missing matching "
@@ -102,13 +104,13 @@ def main() -> int:
     parser.add_argument(
         "--run-discovery-timeout-seconds",
         type=int,
-        default=180,
+        default=DEFAULT_RUN_DISCOVERY_TIMEOUT_SECONDS,
         help="How long to wait for the tag-triggered Release run to appear.",
     )
     parser.add_argument(
         "--run-completion-timeout-seconds",
         type=int,
-        default=1800,
+        default=DEFAULT_RUN_COMPLETION_TIMEOUT_SECONDS,
         help="How long to wait for the Release run to complete.",
     )
     parser.add_argument(
@@ -117,7 +119,11 @@ def main() -> int:
         default=15,
         help="Polling interval used while waiting for Release workflow evidence.",
     )
-    args = parser.parse_args()
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
 
     if args.event_name != "push" or args.ref not in {"refs/heads/main", "refs/heads/master"}:
         print("version-release-guard: skipped (not a push to main/master).")

--- a/scripts/check_version_release_evidence_tests.py
+++ b/scripts/check_version_release_evidence_tests.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Focused tests for the version/release evidence guard CLI contract."""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+import check_version_release_evidence as guard
+
+
+REQUIRED_ARGS = [
+    "--event-name",
+    "pull_request",
+    "--ref",
+    "refs/pull/1/merge",
+    "--after",
+    "a" * 40,
+    "--repo",
+    "example/trust-platform",
+]
+
+
+class VersionReleaseEvidenceParserTests(unittest.TestCase):
+    def test_default_completion_wait_covers_slow_release_builds(self) -> None:
+        args = guard.build_parser().parse_args(REQUIRED_ARGS)
+
+        self.assertEqual(args.run_completion_timeout_seconds, 90 * 60)
+
+    def test_completion_wait_can_be_overridden(self) -> None:
+        args = guard.build_parser().parse_args(
+            [*REQUIRED_ARGS, "--run-completion-timeout-seconds", "7200"]
+        )
+
+        self.assertEqual(args.run_completion_timeout_seconds, 7200)
+
+    def test_ci_job_budget_exceeds_guard_wait(self) -> None:
+        workflow = (Path(__file__).resolve().parents[1] / ".github/workflows/ci.yml").read_text(
+            encoding="utf-8"
+        )
+        job = re.search(
+            r"(?ms)^  version-release-guard:\n(?P<body>.*?)(?=^  [a-zA-Z0-9_-]+:\n|\Z)",
+            workflow,
+        )
+
+        self.assertIsNotNone(job)
+        timeout = re.search(r"(?m)^    timeout-minutes: (?P<minutes>\d+)$", job["body"])
+        self.assertIsNotNone(timeout)
+        self.assertGreater(
+            int(timeout["minutes"]) * 60,
+            guard.DEFAULT_RUN_COMPLETION_TIMEOUT_SECONDS
+            + 2 * guard.DEFAULT_RUN_DISCOVERY_TIMEOUT_SECONDS
+            + 5 * 60,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_check_version_release_evidence.py
+++ b/scripts/test_check_version_release_evidence.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Focused tests for the version/release evidence guard CLI contract."""
+"""Regression tests for the version/release evidence guard CLI contract."""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary

- extend the matching Release completion wait from 30 to 90 minutes
- give the outer Version Release Guard job a 120-minute budget
- test parser defaults, overrides, and workflow-to-script timeout parity in the required Format job
- bump synchronized release metadata to 0.24.31

## Why

The v0.24.30 Release was healthy but its cold Windows artifact build took 36 minutes and the complete workflow took about 39 minutes. Main CI failed at the former 30-minute evidence boundary, then passed unchanged after Release completed. The new budgets preserve fail-closed release evidence while allowing the real release critical path to finish.

Regression-test-first: `python3 scripts/test_check_version_release_evidence.py`

## Validation

- `python3 scripts/test_check_version_release_evidence.py`
- `python3 -m py_compile scripts/check_version_release_evidence.py scripts/test_check_version_release_evidence.py`
- `python3 scripts/check_release_version_alignment.py`
- `python3 scripts/check_gate_observability.py`
- `python3 scripts/check_regression_test_first.py --self-test`
- `trust-builder` Rust 1.97.0: `just fmt`
- `trust-builder` Rust 1.97.0: `just clippy`
- `trust-builder` Rust 1.97.0: `cargo clippy --all-targets --all-features -- -D warnings`
- `trust-builder` Rust 1.97.0: clean-target `just test-all`
