### PR TITLE
Fix v0.24.34 browser IDE docs capture authorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Target release: `v0.24.34`
 
 ### Fixed
 
+- ci/docs: Browser IDE capture automation now requests the editor session
+  required to switch the active tutorial project, keeping post-merge docs
+  captures aligned with the IDE authorization contract.
 - vscode/trust-runtime: Windows ADS discovery now uses the installed TwinCAT
   router for same-computer port and symbol operations, and Devices & Connections
   no longer offers an unverified ADS identity as an actionable fallback device.

--- a/scripts/captures/browser/ide-home.spec.mjs
+++ b/scripts/captures/browser/ide-home.spec.mjs
@@ -24,7 +24,7 @@ test("capture browser ide with tutorial loaded", async ({ page }) => {
     const response = await fetch("/api/ide/session", {
       method: "POST",
       headers: {"Content-Type": "application/json"},
-      body: JSON.stringify({role: "viewer"}),
+      body: JSON.stringify({role: "editor"}),
     });
     if (!response.ok) {
       throw new Error(`session bootstrap failed: ${response.status}`);


### PR DESCRIPTION
## Scope

Narrow post-merge release-gate repair for v0.24.34. The browser IDE docs capture now requests the editor session required by the existing project-switch authorization contract. No product runtime or UI source changed.

## Test-first evidence

- Red: post-merge Docs Captures run 29415823505 reached `ide-home.spec.mjs` and failed `project open failed: 403` because the test requested a viewer session.
- Green: the same focused Playwright capture passed on `trust-builder`.
- Green: the complete four-test browser capture suite passed on `trust-builder`.
- Version alignment remains `0.24.34`; accepted `networkCanvasWebview.js` SHA256 remains `0b78c0d77897ec5408df870ca0dd4ae1bdccc40555b3de5d203a2b4a31d3c82a`.

Regression-test-first: yes.