### PR TITLE
ci: validate docs captures before merge

### DIFF
--- a/.github/workflows/docs-captures.yml
+++ b/.github/workflows/docs-captures.yml
@@ -1,6 +1,18 @@
 name: Docs Captures
 
 on:
+  pull_request:
+    paths:
+      - ".github/workflows/docs-captures.yml"
+      - "docs/public/assets/capture-inventory.json"
+      - "docs/public/assets/images/**"
+      - "editors/vscode/**"
+      - "examples/tutorials/12_hmi_pid_process_dashboard/**"
+      - "manual-tests/trust-lsp-smoke/**"
+      - "scripts/build_browser_analysis_wasm_spike.sh"
+      - "scripts/captures/**"
+      - "scripts/check_public_docs_assets.py"
+      - "scripts/generate_public_docs_media.py"
   push:
     branches:
       - main
@@ -20,8 +32,7 @@ on:
     - cron: "0 4 * * *"
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -31,6 +42,8 @@ jobs:
   refresh:
     name: Refresh Automated Docs Captures
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
 
@@ -92,6 +105,23 @@ jobs:
           path: |
             docs/public/assets/images/**/*.png
             docs/public/assets/images/**/*.gif
+
+  create-refresh-pr:
+    name: Create Capture Refresh PR
+    needs: refresh
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download refreshed captures
+        uses: actions/download-artifact@v8
+        with:
+          name: docs-captures
+          path: docs/public/assets/images
 
       - name: Create capture refresh PR
         continue-on-error: true

--- a/scripts/tests/test_docs_captures_workflow.py
+++ b/scripts/tests/test_docs_captures_workflow.py
@@ -1,0 +1,42 @@
+from pathlib import Path
+import unittest
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "docs-captures.yml"
+
+
+class DocsCapturesWorkflowContractTests(unittest.TestCase):
+    def test_pull_requests_run_read_only_captures_without_refresh_pr_writes(self) -> None:
+        workflow = yaml.load(WORKFLOW.read_text(), Loader=yaml.BaseLoader)
+
+        triggers = workflow["on"]
+        self.assertIn("pull_request", triggers)
+        self.assertEqual(
+            triggers["pull_request"]["paths"],
+            triggers["push"]["paths"],
+            "PR and main-push capture paths must stay aligned",
+        )
+        self.assertEqual(workflow["permissions"], {"contents": "read"})
+
+        refresh = workflow["jobs"]["refresh"]
+        self.assertEqual(refresh["permissions"], {"contents": "read"})
+        refresh_steps = [step.get("name") for step in refresh["steps"]]
+        self.assertNotIn("Create capture refresh PR", refresh_steps)
+
+        refresh_pr = workflow["jobs"]["create-refresh-pr"]
+        self.assertEqual(refresh_pr["needs"], "refresh")
+        self.assertEqual(refresh_pr["if"], "github.event_name != 'pull_request'")
+        self.assertEqual(
+            refresh_pr["permissions"],
+            {"contents": "write", "pull-requests": "write"},
+        )
+        refresh_pr_steps = [step.get("name") for step in refresh_pr["steps"]]
+        self.assertIn("Download refreshed captures", refresh_pr_steps)
+        self.assertIn("Create capture refresh PR", refresh_pr_steps)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- run Docs Captures for relevant pull-request changes before merge
- keep capture validation read-only and isolate refresh-PR writes to non-PR events
- add a focused workflow contract regression test

## Test-first proof

RED: python3 -m unittest scripts.tests.test_docs_captures_workflow -v failed because the pull_request trigger was absent.

GREEN: python3 -m unittest scripts.tests.test_docs_captures_workflow scripts.tests.test_diagram_workflow -v passed all 3 tests.

Regression-test-first: scripts/tests/test_docs_captures_workflow.py

## Additional validation

- workflow YAML parsed with PyYAML
- git diff --check
- trust-release-hygiene, trust-ci-release-gates, and trust-remote-builder passed quick_validate.py

No version bump: this is an internal CI safety change with no shipped product behavior change.