### PR TITLE
Decouple release publication from CI

### DIFF
--- a/.codex/skills/trust-ci-release-gates/SKILL.md
+++ b/.codex/skills/trust-ci-release-gates/SKILL.md
@@ -30,9 +30,10 @@ push-and-repair attempts.
      prepare --remote-worktree '<clean exact-SHA trust-builder worktree>'
    ```
 
-   Preparation runs bootstrap parity, complete-diff planning, catalog staleness, the focused
-   verification suite, metadata/self-tests, the exact strict PR gate, and final remote broad
-   gates. Any commit, base movement, missing command, or dirty checkout invalidates the artifact.
+   Preparation runs only cheap bootstrap and planning checks locally. Catalog staleness,
+   metadata/self-tests, the exact strict PR gate, and all broad gates run in the clean exact-SHA
+   `trust-builder` worktree with an absolute `CARGO_TARGET_DIR`. Any commit, base movement,
+   missing command, or dirty checkout invalidates the artifact.
 2. Push the frozen candidate once. The installed pre-push hook rejects a release-sensitive push
    without a passing artifact for the exact head and current base.
 3. Wait for every required GitHub check. Before editing after a red candidate, collect the whole

--- a/.codex/skills/trust-ci-release-gates/scripts/release_candidate_guard.py
+++ b/.codex/skills/trust-ci-release-gates/scripts/release_candidate_guard.py
@@ -496,7 +496,7 @@ def parser() -> argparse.ArgumentParser:
     prepare_parser.add_argument("--remote-host", default="trust-builder")
     prepare_parser.add_argument("--remote-worktree", required=True)
     prepare_parser.add_argument(
-        "--remote-target", default="$HOME/.cache/codex-targets/trust-platform-gate"
+        "--remote-target", default="/home/johannes/.cache/codex-targets/trust-platform-gate"
     )
     prepare_parser.add_argument("--fetch", action=argparse.BooleanOptionalAction, default=True)
     prepare_parser.set_defaults(handler=prepare_command)

--- a/.codex/skills/trust-ci-release-gates/scripts/release_candidate_guard_tests.py
+++ b/.codex/skills/trust-ci-release-gates/scripts/release_candidate_guard_tests.py
@@ -143,6 +143,17 @@ class ReleaseCandidateGuardTests(unittest.TestCase):
             'xvfb-run -a -s "-screen 0 1920x1080x24" npm test',
         )
 
+    def test_expensive_validation_is_remote_with_absolute_target(self) -> None:
+        source = Path(candidate_prepare.__file__).read_text(encoding="utf-8")
+        guard_source = Path(candidate_prepare.guard.__file__).read_text(encoding="utf-8")
+
+        self.assertNotIn('command_record("strict_gate", strict_command, cwd=repo, scope="local"', source)
+        self.assertNotIn('default="$HOME/.cache/codex-targets/trust-platform-gate"', guard_source)
+        self.assertIn(
+            'default="/home/johannes/.cache/codex-targets/trust-platform-gate"',
+            guard_source,
+        )
+
     def test_stale_head_and_base_are_rejected(self) -> None:
         artifact = self.passing_artifact()
         artifact["head"] = "1" * 40

--- a/.codex/skills/trust-ci-release-gates/scripts/release_candidate_prepare.py
+++ b/.codex/skills/trust-ci-release-gates/scripts/release_candidate_prepare.py
@@ -231,55 +231,31 @@ def prepare(args: Any) -> int:
             log_dir=log_dir,
         )
 
-    local_commands = (
-        ("catalog_staleness", [sys.executable, "scripts/check_test_catalog_staleness.py"]),
-        ("selftests", [sys.executable, "scripts/check_verification_tooling_selftests.py"]),
-    )
-    for command_id, command in local_commands:
-        records.append(command_record(command_id, command, cwd=repo, scope="local", log_dir=log_dir))
-    if not stage_passed(records, tuple(command_id for command_id, _ in local_commands)):
-        return finish_artifact(
-            repo,
-            head=head,
-            base_ref=args.base,
-            base_sha=base_sha,
-            vscode_changed=vscode_changed,
-            records=records,
-            log_dir=log_dir,
-        )
-
-    strict_command = [
-        sys.executable,
-        "scripts/verification_report_gate.py",
-        "--base",
-        base_sha,
-        "--head",
-        head,
-        "--intent",
-        args.intent,
-        "--strict",
-        "--out-dir",
-        "target/gate-artifacts/verification-release-candidate",
-    ]
-    records.append(
-        command_record("strict_gate", strict_command, cwd=repo, scope="local", log_dir=log_dir)
-    )
-    if not stage_passed(records, ("strict_gate",)):
-        return finish_artifact(
-            repo,
-            head=head,
-            base_ref=args.base,
-            base_sha=base_sha,
-            vscode_changed=vscode_changed,
-            records=records,
-            log_dir=log_dir,
-        )
-
     remote_head_check = (
         f'test "$(git rev-parse HEAD)" = {shlex.quote(head)} && '
         'test -z "$(git status --porcelain=v1 --untracked-files=all)"'
     )
-    remote_commands = [("remote_exact_head", remote_head_check)]
+    strict_command = shlex.join(
+        [
+            "python3",
+            "scripts/verification_report_gate.py",
+            "--base",
+            base_sha,
+            "--head",
+            head,
+            "--intent",
+            args.intent,
+            "--strict",
+            "--out-dir",
+            "target/gate-artifacts/verification-release-candidate",
+        ]
+    )
+    remote_commands = [
+        ("remote_exact_head", remote_head_check),
+        ("catalog_staleness", "python3 scripts/check_test_catalog_staleness.py"),
+        ("selftests", "python3 scripts/check_verification_tooling_selftests.py"),
+        ("strict_gate", strict_command),
+    ]
     if vscode_changed:
         remote_commands.append(("remote_vscode", remote_vscode_command()))
     remote_commands.extend(

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,13 +34,10 @@ jobs:
       - name: Validate owned dependency exception lifetimes
         run: python3 scripts/check_dependency_exceptions.py
 
-      - name: Validate tag and CI evidence
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Validate release tag
         run: |
           python3 scripts/check_release_tag_preflight.py \
-            --tag "${{ github.ref_name }}" \
-            --repo "${{ github.repository }}"
+            --tag "${{ github.ref_name }}"
 
   runtime-vm-validation:
     name: Runtime VM Validation
@@ -72,6 +69,30 @@ jobs:
           TRUST_VM_DETERMINISM_ITERATIONS=3 \
           TRUST_VM_DETERMINISM_TEST_THREADS=1 \
           ./scripts/runtime_vm_determinism_reliability_gate.sh
+
+      - name: Run release conformance suite
+        run: |
+          mkdir -p conformance-artifacts
+          cargo run -p trust-runtime --bin trust-runtime -- \
+            conformance \
+            --suite-root conformance \
+            --output conformance-artifacts/conformance-pass-1.json
+
+      - name: Validate and render conformance result
+        run: |
+          python3 scripts/validate_conformance_summary_schema.py \
+            --schema conformance/schemas/summary-v1.schema.json \
+            --schema conformance/schemas/summary-v2.schema.json \
+            --summary conformance-artifacts/conformance-pass-1.json
+          python3 scripts/render_conformance_summary.py \
+            --input conformance-artifacts/conformance-pass-1.json \
+            --output conformance-artifacts/conformance-pass-1.md
+
+      - name: Upload release conformance result
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-conformance
+          path: conformance-artifacts/
 
       - name: Upload runtime VM validation artifacts
         if: ${{ always() }}
@@ -290,7 +311,7 @@ jobs:
 
   publish:
     name: Publish
-    needs: [build, runtime-vm-validation]
+    needs: [release-preflight, build, runtime-vm-validation]
     runs-on: ubuntu-latest
     env:
       VSCE_PAT: ${{ secrets.VSCE_PAT }}
@@ -318,25 +339,11 @@ jobs:
           pattern: trust-lsp-*
           merge-multiple: true
 
-      - name: Download successful CI conformance artifact
-        shell: bash
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          ci_run_id="$(gh run list \
-            --workflow ci.yml \
-            --commit "${GITHUB_SHA}" \
-            --status success \
-            --json databaseId \
-            --jq '.[0].databaseId')"
-          if [ -z "${ci_run_id}" ] || [ "${ci_run_id}" = "null" ]; then
-            echo "No successful CI run found for ${GITHUB_SHA}"
-            exit 1
-          fi
-          gh run download "${ci_run_id}" \
-            --name conformance-suite \
-            --dir conformance-artifacts
+      - name: Download release conformance artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: release-conformance
+          path: conformance-artifacts
 
       - name: Generate result-derived conformance status
         shell: bash

--- a/scripts/check_release_tag_preflight.py
+++ b/scripts/check_release_tag_preflight.py
@@ -1,19 +1,13 @@
 #!/usr/bin/env python3
-"""Validate tag-triggered release preconditions."""
+"""Validate the tag-local preconditions for a release workflow."""
 
 from __future__ import annotations
 
 import argparse
-import json
-import os
 import subprocess
 import sys
 import tomllib
-import urllib.error
-import urllib.parse
-import urllib.request
 from pathlib import Path
-from typing import Any
 
 
 def fail(message: str) -> int:
@@ -34,70 +28,25 @@ def run_git(args: list[str]) -> str:
         capture_output=True,
     )
     if result.returncode != 0:
-        raise RuntimeError(
-            f"git {' '.join(args)} failed: {result.stderr.strip()}"
-        )
+        raise RuntimeError(f"git {' '.join(args)} failed: {result.stderr.strip()}")
     return result.stdout.strip()
 
 
-def github_api_get(
-    repo: str,
-    path: str,
-    token: str,
-    query: dict[str, str] | None = None,
-) -> tuple[int, dict[str, Any]]:
-    qs = ""
-    if query:
-        qs = "?" + urllib.parse.urlencode(query)
-    req = urllib.request.Request(
-        f"https://api.github.com/repos/{repo}{path}{qs}",
-        headers={
-            "Accept": "application/vnd.github+json",
-            "Authorization": f"Bearer {token}",
-            "User-Agent": "trust-release-tag-preflight",
-        },
+def tag_is_on_main(tagged_sha: str) -> bool:
+    result = subprocess.run(
+        ["git", "merge-base", "--is-ancestor", tagged_sha, "origin/main"],
+        check=False,
+        text=True,
+        capture_output=True,
     )
-    try:
-        with urllib.request.urlopen(req) as response:
-            body = response.read().decode("utf-8")
-            return response.status, json.loads(body) if body else {}
-    except urllib.error.HTTPError as exc:
-        raw = exc.read().decode("utf-8", errors="replace")
-        try:
-            payload = json.loads(raw) if raw else {}
-        except json.JSONDecodeError:
-            payload = {"message": raw}
-        return exc.code, payload
-
-
-def ci_green_for_sha(repo: str, sha: str, token: str) -> tuple[bool, str]:
-    status, payload = github_api_get(
-        repo,
-        "/actions/workflows/ci.yml/runs",
-        token,
-        query={"head_sha": sha, "per_page": "100"},
-    )
-    if status != 200:
-        return False, f"GitHub API status {status}: {payload.get('message', 'unknown error')}"
-
-    runs = payload.get("workflow_runs", [])
-    successful = [
-        run
-        for run in runs
-        if run.get("status") == "completed" and run.get("conclusion") == "success"
-    ]
-    if successful:
-        html_url = successful[0].get("html_url", "<missing url>")
-        return True, f"CI success found for {sha}: {html_url}"
-    return False, f"No successful CI workflow run found for tagged SHA {sha}."
+    return result.returncode == 0
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(
-        description="Fail a tag-triggered release when tag/version/CI evidence is missing."
+        description="Fail a tag-triggered release when its tag or version is invalid."
     )
     parser.add_argument("--tag", required=True)
-    parser.add_argument("--repo", required=True)
     args = parser.parse_args()
 
     version = workspace_version()
@@ -109,20 +58,22 @@ def main() -> int:
         )
 
     try:
+        tag_type = run_git(["cat-file", "-t", f"refs/tags/{args.tag}"])
         tagged_sha = run_git(["rev-parse", f"{args.tag}^{{}}"])
+        head_sha = run_git(["rev-parse", "HEAD"])
     except RuntimeError as error:
         return fail(str(error))
 
-    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN") or ""
-    if not token:
-        return fail("GITHUB_TOKEN is required to verify CI evidence for the release tag.")
-
-    ok, message = ci_green_for_sha(args.repo, tagged_sha, token)
-    if not ok:
-        return fail(message)
+    if tag_type != "tag":
+        return fail(f"Release tag {args.tag} must be an annotated tag.")
+    if tagged_sha != head_sha:
+        return fail(
+            f"Release checkout HEAD {head_sha} does not match {args.tag} at {tagged_sha}."
+        )
+    if not tag_is_on_main(tagged_sha):
+        return fail(f"Release tag {args.tag} is not reachable from origin/main.")
 
     print(f"release-tag-preflight: OK ({expected_tag} -> {tagged_sha})")
-    print(message)
     return 0
 
 

--- a/scripts/test_check_version_release_evidence.py
+++ b/scripts/test_check_version_release_evidence.py
@@ -4,10 +4,17 @@
 from __future__ import annotations
 
 import re
+import subprocess
 import unittest
 from pathlib import Path
+from unittest import mock
 
-import check_version_release_evidence as guard
+try:
+    from scripts import check_release_tag_preflight as tag_preflight
+    from scripts import check_version_release_evidence as guard
+except ModuleNotFoundError:  # Direct `python scripts/...` execution.
+    import check_release_tag_preflight as tag_preflight  # type: ignore[no-redef]
+    import check_version_release_evidence as guard  # type: ignore[no-redef]
 
 
 REQUIRED_ARGS = [
@@ -35,24 +42,36 @@ class VersionReleaseEvidenceParserTests(unittest.TestCase):
 
         self.assertEqual(args.run_completion_timeout_seconds, 7200)
 
-    def test_ci_job_budget_exceeds_guard_wait(self) -> None:
-        workflow = (Path(__file__).resolve().parents[1] / ".github/workflows/ci.yml").read_text(
-            encoding="utf-8"
-        )
-        job = re.search(
-            r"(?ms)^  version-release-guard:\n(?P<body>.*?)(?=^  [a-zA-Z0-9_-]+:\n|\Z)",
-            workflow,
-        )
+    def test_release_workflow_does_not_wait_on_ci(self) -> None:
+        repo = Path(__file__).resolve().parents[1]
+        release_workflow = (repo / ".github/workflows/release.yml").read_text(encoding="utf-8")
 
-        self.assertIsNotNone(job)
-        timeout = re.search(r"(?m)^    timeout-minutes: (?P<minutes>\d+)$", job["body"])
-        self.assertIsNotNone(timeout)
-        self.assertGreater(
-            int(timeout["minutes"]) * 60,
-            guard.DEFAULT_RUN_COMPLETION_TIMEOUT_SECONDS
-            + 2 * guard.DEFAULT_RUN_DISCOVERY_TIMEOUT_SECONDS
-            + 5 * 60,
-        )
+        self.assertNotIn("ci_run_id", release_workflow)
+        self.assertNotIn("gh run download", release_workflow)
+        self.assertNotRegex(release_workflow, r"(?m)^  release-conformance:$")
+        self.assertIn("name: Runtime VM Validation", release_workflow)
+        self.assertIn("name: release-conformance", release_workflow)
+
+    def test_release_preflight_has_no_ci_api_contract(self) -> None:
+        source = Path(tag_preflight.__file__).read_text(encoding="utf-8")
+
+        self.assertNotIn("ci_green_for_sha", source)
+        self.assertNotIn("GITHUB_TOKEN", source)
+        self.assertNotIn("github_api_get", source)
+
+    def test_release_tag_must_be_on_main(self) -> None:
+        with mock.patch.object(
+            tag_preflight.subprocess,
+            "run",
+            return_value=subprocess.CompletedProcess([], 0, "", ""),
+        ):
+            self.assertTrue(tag_preflight.tag_is_on_main("a" * 40))
+        with mock.patch.object(
+            tag_preflight.subprocess,
+            "run",
+            return_value=subprocess.CompletedProcess([], 1, "", ""),
+        ):
+            self.assertFalse(tag_preflight.tag_is_on_main("a" * 40))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- remove the circular Release-to-CI dependency
- generate conformance evidence inside the tag-triggered Release workflow
- run expensive release-candidate validation on trust-builder with an absolute Cargo target path

## Validation
- exact candidate: `2c6e1b0f6290f2a9d051dc4b7e62fb2d9606ea61`
- focused release/guard tests: green
- trust-builder strict verification: green
- trust-builder `just fmt`: green
- trust-builder `just clippy`: green
- trust-builder `just test-all`: green

No product, ADS, runtime, UI, or VS Code behavior changes.